### PR TITLE
Custom locale loader

### DIFF
--- a/lib/rules/no-html-messages.js
+++ b/lib/rules/no-html-messages.js
@@ -54,7 +54,7 @@ function create (context) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'])
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-html-messages`)

--- a/lib/rules/no-html-messages.js
+++ b/lib/rules/no-html-messages.js
@@ -10,7 +10,8 @@ const {
   findExistLocaleMessage,
   getLocaleMessages,
   extractJsonInfo,
-  generateJsonAst
+  generateJsonAst,
+  validateSettings,
 } = require('../utils/index')
 const debug = require('debug')('eslint-plugin-vue-i18n:no-html-messages')
 
@@ -45,16 +46,11 @@ function create (context) {
     return {}
   }
 
-  const { settings } = context
-  if (!settings['vue-i18n'] || !settings['vue-i18n'].localeDir) {
-    context.report({
-      loc: UNEXPECTED_ERROR_LOCATION,
-      message: `You need to 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`
-    })
+  if (!validateSettings(context)) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'])
+  const localeMessages = getLocaleMessages(context)
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-html-messages`)

--- a/lib/rules/no-html-messages.js
+++ b/lib/rules/no-html-messages.js
@@ -54,7 +54,7 @@ function create (context) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-html-messages`)

--- a/lib/rules/no-html-messages.js
+++ b/lib/rules/no-html-messages.js
@@ -6,12 +6,11 @@
 const { extname } = require('path')
 const parse5 = require('parse5')
 const {
-  UNEXPECTED_ERROR_LOCATION,
   findExistLocaleMessage,
   getLocaleMessages,
   extractJsonInfo,
   generateJsonAst,
-  validateSettings,
+  validateSettings
 } = require('../utils/index')
 const debug = require('debug')('eslint-plugin-vue-i18n:no-html-messages')
 

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -20,7 +20,7 @@ function create (context) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'])
 
   return defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='t']" (node) {

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -4,12 +4,10 @@
 'use strict'
 
 const {
-  UNEXPECTED_ERROR_LOCATION,
   defineTemplateBodyVisitor,
   getLocaleMessages,
-  getSettings,
   findMissingsFromLocaleMessages,
-  validateSettings,
+  validateSettings
 } = require('../utils/index')
 
 function create (context) {

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -7,20 +7,17 @@ const {
   UNEXPECTED_ERROR_LOCATION,
   defineTemplateBodyVisitor,
   getLocaleMessages,
-  findMissingsFromLocaleMessages
+  getSettings,
+  findMissingsFromLocaleMessages,
+  validateSettings,
 } = require('../utils/index')
 
 function create (context) {
-  const { settings } = context
-  if (!settings['vue-i18n'] || !settings['vue-i18n'].localeDir) {
-    context.report({
-      loc: UNEXPECTED_ERROR_LOCATION,
-      message: `You need to set 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`
-    })
+  if (!validateSettings(context)) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'])
+  const localeMessages = getLocaleMessages(context)
 
   return defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='t']" (node) {

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -21,7 +21,7 @@ function create (context) {
   }
 
   const localeDir = settings['vue-i18n'].localeDir
-  const localeMessages = getLocaleMessages(localeDir)
+  const localeMessages = getLocaleMessages(localeDir, settings['vue-i18n'].localeLoader)
 
   return defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='t']" (node) {

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -20,37 +20,36 @@ function create (context) {
     return {}
   }
 
-  const localeDir = settings['vue-i18n'].localeDir
-  const localeMessages = getLocaleMessages(localeDir, settings['vue-i18n'].localeLoader)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
 
   return defineTemplateBodyVisitor(context, {
     "VAttribute[directive=true][key.name='t']" (node) {
-      checkDirective(context, localeDir, localeMessages, node)
+      checkDirective(context, localeMessages, node)
     },
 
     "VAttribute[directive=true][key.name.name='t']" (node) {
-      checkDirective(context, localeDir, localeMessages, node)
+      checkDirective(context, localeMessages, node)
     },
 
     "VElement[name=i18n] > VStartTag > VAttribute[key.name='path']" (node) {
-      checkComponent(context, localeDir, localeMessages, node)
+      checkComponent(context, localeMessages, node)
     },
 
     "VElement[name=i18n] > VStartTag > VAttribute[key.name.name='path']" (node) {
-      checkComponent(context, localeDir, localeMessages, node)
+      checkComponent(context, localeMessages, node)
     },
 
     CallExpression (node) {
-      checkCallExpression(context, localeDir, localeMessages, node)
+      checkCallExpression(context, localeMessages, node)
     }
   }, {
     CallExpression (node) {
-      checkCallExpression(context, localeDir, localeMessages, node)
+      checkCallExpression(context, localeMessages, node)
     }
   })
 }
 
-function checkDirective (context, localeDir, localeMessages, node) {
+function checkDirective (context, localeMessages, node) {
   if ((node.value && node.value.type === 'VExpressionContainer') &&
   (node.value.expression && node.value.expression.type === 'Literal')) {
     const key = node.value.expression.value
@@ -58,28 +57,28 @@ function checkDirective (context, localeDir, localeMessages, node) {
       // TODO: should be error
       return
     }
-    const missings = findMissingsFromLocaleMessages(localeMessages, key, localeDir)
+    const missings = findMissingsFromLocaleMessages(localeMessages, key)
     if (missings.length) {
       missings.forEach(missing => context.report({ node, ...missing }))
     }
   }
 }
 
-function checkComponent (context, localeDir, localeMessages, node) {
+function checkComponent (context, localeMessages, node) {
   if (node.value && node.value.type === 'VLiteral') {
     const key = node.value.value
     if (!key) {
       // TODO: should be error
       return
     }
-    const missings = findMissingsFromLocaleMessages(localeMessages, key, localeDir)
+    const missings = findMissingsFromLocaleMessages(localeMessages, key)
     if (missings.length) {
       missings.forEach(missing => context.report({ node, ...missing }))
     }
   }
 }
 
-function checkCallExpression (context, localeDir, localeMessages, node) {
+function checkCallExpression (context, localeMessages, node) {
   const funcName = (node.callee.type === 'MemberExpression' && node.callee.property.name) || node.callee.name
 
   if (!/^(\$t|t|\$tc|tc)$/.test(funcName) || !node.arguments || !node.arguments.length) {
@@ -95,7 +94,7 @@ function checkCallExpression (context, localeDir, localeMessages, node) {
     return
   }
 
-  const missings = findMissingsFromLocaleMessages(localeMessages, key, localeDir)
+  const missings = findMissingsFromLocaleMessages(localeMessages, key)
   if (missings.length) {
     missings.forEach(missing => context.report({ node, ...missing }))
   }

--- a/lib/rules/no-unused-keys.js
+++ b/lib/rules/no-unused-keys.js
@@ -88,7 +88,7 @@ function create (context) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'])
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-unused-keys`)

--- a/lib/rules/no-unused-keys.js
+++ b/lib/rules/no-unused-keys.js
@@ -12,7 +12,8 @@ const {
   findExistLocaleMessage,
   getLocaleMessages,
   extractJsonInfo,
-  generateJsonAst
+  generateJsonAst,
+  validateSettings,
 } = require('../utils/index')
 const debug = require('debug')('eslint-plugin-vue-i18n:no-unused-keys')
 
@@ -79,16 +80,11 @@ function create (context) {
     return {}
   }
 
-  const { settings } = context
-  if (!settings['vue-i18n'] || !settings['vue-i18n'].localeDir) {
-    context.report({
-      loc: UNEXPECTED_ERROR_LOCATION,
-      message: `You need to 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`
-    })
+  if (!validateSettings(context)) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'])
+  const localeMessages = getLocaleMessages(context)
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-unused-keys`)

--- a/lib/rules/no-unused-keys.js
+++ b/lib/rules/no-unused-keys.js
@@ -88,7 +88,7 @@ function create (context) {
     return {}
   }
 
-  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir)
+  const localeMessages = getLocaleMessages(settings['vue-i18n'].localeDir, settings['vue-i18n'].localeLoader)
   const targetLocaleMessage = findExistLocaleMessage(filename, localeMessages)
   if (!targetLocaleMessage) {
     debug(`ignore ${filename} in no-unused-keys`)

--- a/lib/rules/no-unused-keys.js
+++ b/lib/rules/no-unused-keys.js
@@ -13,7 +13,7 @@ const {
   getLocaleMessages,
   extractJsonInfo,
   generateJsonAst,
-  validateSettings,
+  validateSettings
 } = require('../utils/index')
 const debug = require('debug')('eslint-plugin-vue-i18n:no-unused-keys')
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -40,20 +40,16 @@ function loadLocaleMessages (pattern) {
   })
 }
 
-let localeMessages = null // locale messages
-let localeDir = null // locale dir
+let localeDirCache = {} // locale messages
 
-function getLocaleMessages (settings) {
+function getLocaleMessages (context) {
+  const settings = getSettings(context)
+
   if (settings.locale && settings.messages) {
-    return settings.messages[settings.locale]
+    return [{ messages: settings.messages[settings.locale] }]
   }
-  if (localeDir !== settings.localeDir) {
-    localeDir = settings.localeDir
-    localeMessages = loadLocaleMessages(localeDir)
-  } else {
-    localeMessages = localeMessages || loadLocaleMessages(localeDir)
-  }
-  return localeMessages
+
+  return localeDirCache[settings.localeDir] = localeDirCache[settings.localeDir] || loadLocaleMessages(settings.localeDir)
 }
 
 function findMissingsFromLocaleMessages (localeMessages, key) {
@@ -109,6 +105,22 @@ function generateJsonAst (context, json, filename) {
   return ast
 }
 
+function getSettings(context) {
+  return context.settings['vue-i18n'] || {}
+}
+
+function validateSettings(context) {
+  const settings = getSettings(context)
+  const isValid = !!(settings.locale || settings.localeDir || settings.messages)
+  if (!isValid) {
+    context.report({
+      loc: UNEXPECTED_ERROR_LOCATION,
+      message: 'You need to define locales in settings. See the eslint-plugin-vue-i18n documentation',
+    })
+  }
+  return isValid
+}
+
 module.exports = {
   UNEXPECTED_ERROR_LOCATION,
   defineTemplateBodyVisitor,
@@ -116,5 +128,6 @@ module.exports = {
   findMissingsFromLocaleMessages,
   findExistLocaleMessage,
   extractJsonInfo,
-  generateJsonAst
+  generateJsonAst,
+  validateSettings,
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -43,10 +43,10 @@ function loadLocaleMessages (pattern) {
 let localeMessages = null // locale messages
 let localeDir = null // locale dir
 
-function getLocaleMessages (localeDirectory, customLoader) {
-  const loader = customLoader || loadLocaleMessages
-  if (localeDir !== localeDirectory) {
-    localeDir = localeDirectory
+function getLocaleMessages (settings) {
+  const loader = settings.localeLoader || loadLocaleMessages
+  if (localeDir !== settings.localeDir) {
+    localeDir = settings.localeDir
     localeMessages = loader(localeDir)
   } else {
     localeMessages = localeMessages || loader(localeDir)

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -43,12 +43,13 @@ function loadLocaleMessages (pattern) {
 let localeMessages = null // locale messages
 let localeDir = null // locale dir
 
-function getLocaleMessages (localeDirectory) {
+function getLocaleMessages (localeDirectory, customLoader) {
+  const loader = customLoader || loadLocaleMessages
   if (localeDir !== localeDirectory) {
     localeDir = localeDirectory
-    localeMessages = loadLocaleMessages(localeDir)
+    localeMessages = loader(localeDir)
   } else {
-    localeMessages = localeMessages || loadLocaleMessages(localeDir)
+    localeMessages = localeMessages || loader(localeDir)
   }
   return localeMessages
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -44,12 +44,14 @@ let localeMessages = null // locale messages
 let localeDir = null // locale dir
 
 function getLocaleMessages (settings) {
-  const loader = settings.localeLoader || loadLocaleMessages
+  if (settings.locale && settings.messages) {
+    return settings.messages[settings.locale]
+  }
   if (localeDir !== settings.localeDir) {
     localeDir = settings.localeDir
-    localeMessages = loader(localeDir)
+    localeMessages = loadLocaleMessages(localeDir)
   } else {
-    localeMessages = localeMessages || loader(localeDir)
+    localeMessages = localeMessages || loadLocaleMessages(localeDir)
   }
   return localeMessages
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -40,16 +40,20 @@ function loadLocaleMessages (pattern) {
   })
 }
 
-let localeDirCache = {} // locale messages
+const localeDirCache = {} // locale messages
 
 function getLocaleMessages (context) {
   const settings = getSettings(context)
 
-  if (settings.locale && settings.messages) {
-    return [{ messages: settings.messages[settings.locale] }]
+  if (settings.locales) {
+    return settings.locales
   }
 
-  return localeDirCache[settings.localeDir] = localeDirCache[settings.localeDir] || loadLocaleMessages(settings.localeDir)
+  if (!localeDirCache[settings.localeDir]) {
+    localeDirCache[settings.localeDir] = loadLocaleMessages(settings.localeDir)
+  }
+
+  return localeDirCache[settings.localeDir]
 }
 
 function findMissingsFromLocaleMessages (localeMessages, key) {
@@ -105,17 +109,17 @@ function generateJsonAst (context, json, filename) {
   return ast
 }
 
-function getSettings(context) {
+function getSettings (context) {
   return context.settings['vue-i18n'] || {}
 }
 
-function validateSettings(context) {
+function validateSettings (context) {
   const settings = getSettings(context)
-  const isValid = !!(settings.locale || settings.localeDir || settings.messages)
+  const isValid = !!(settings.localeDir || settings.locales)
   if (!isValid) {
     context.report({
       loc: UNEXPECTED_ERROR_LOCATION,
-      message: 'You need to define locales in settings. See the eslint-plugin-vue-i18n documentation',
+      message: 'You need to define locales in settings. See the eslint-plugin-vue-i18n documentation'
     })
   }
   return isValid
@@ -129,5 +133,5 @@ module.exports = {
   findExistLocaleMessage,
   extractJsonInfo,
   generateJsonAst,
-  validateSettings,
+  validateSettings
 }

--- a/tests/lib/rules/no-missing-keys.js
+++ b/tests/lib/rules/no-missing-keys.js
@@ -106,7 +106,7 @@ tester.run('no-missing-keys', rule, {
     // settings.vue-i18n.localeDir' error
     code: `$t('missing')`,
     errors: [
-      `You need to set 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`
+      'You need to define locales in settings. See the eslint-plugin-vue-i18n documentation'
     ]
   }, {
     // nested basic

--- a/tests/lib/rules/no-missing-keys.js
+++ b/tests/lib/rules/no-missing-keys.js
@@ -14,6 +14,13 @@ const settings = {
   }
 }
 
+const messageSettings = {
+  'vue-i18n': {
+    locale: 'en',
+    messages: { en: { hello: 'hello world' }},
+  }
+}
+
 const tester = new RuleTester({
   parser: require.resolve('vue-eslint-parser'),
   parserOptions: { ecmaVersion: 2015 }
@@ -60,6 +67,10 @@ tester.run('no-missing-keys', rule, {
     code: `<template>
       <p v-t="'hello'"></p>
     </template>`
+  }, {
+    // using message settings
+    settings: messageSettings,
+    code: `$t('hello')`
   }],
 
   invalid: [{
@@ -117,6 +128,13 @@ tester.run('no-missing-keys', rule, {
       `'missing.path' does not exist`,
       `'missing.path' does not exist`,
       `'missing.path' does not exist`
+    ]
+  }, {
+    // using message settings
+    settings: messageSettings,
+    code: `$t('missing')`,
+    errors: [
+      `'missing' does not exist`
     ]
   }]
 })

--- a/tests/lib/rules/no-missing-keys.js
+++ b/tests/lib/rules/no-missing-keys.js
@@ -14,10 +14,9 @@ const settings = {
   }
 }
 
-const messageSettings = {
+const settingLocales = {
   'vue-i18n': {
-    locale: 'en',
-    messages: { en: { hello: 'hello world' }},
+    locales: [{ name: 'en', messages: { hello: 'hello world' }}]
   }
 }
 
@@ -69,7 +68,7 @@ tester.run('no-missing-keys', rule, {
     </template>`
   }, {
     // using message settings
-    settings: messageSettings,
+    settings: settingLocales,
     code: `$t('hello')`
   }],
 
@@ -131,7 +130,7 @@ tester.run('no-missing-keys', rule, {
     ]
   }, {
     // using message settings
-    settings: messageSettings,
+    settings: settingLocales,
     code: `$t('missing')`,
     errors: [
       `'missing' does not exist`

--- a/tests/lib/rules/no-unused-keys.js
+++ b/tests/lib/rules/no-unused-keys.js
@@ -51,7 +51,7 @@ describe('no-unused-keys', () => {
           .filter(message => message.ruleId === 'vue-i18n/no-unused-keys')
       }).reduce((values, current) => values.concat(current), [])
         .forEach(message => {
-          assert.equal(message.message, `You need to 'localeDir' at 'settings. See the 'eslint-plugin-vue-i18n documentation`)
+          assert.equal(message.message, 'You need to define locales in settings. See the eslint-plugin-vue-i18n documentation')
         })
     })
   })


### PR DESCRIPTION
Adds the ability to swap out `loadLocaleMessages` for your own implementation.

```js
{
    settings: {
        'vue-i18n': {
            localeDir: 'resources/lang/**/*.json',
            localeLoader(pattern) {
                const _ = require('lodash')
                const glob = require('glob')
                const messages = {}

                glob.sync(pattern).forEach(file => {
                    _.set(messages, file.match(/resources\/lang\/(.*)\.json/)[1].replace(/\//g, '.'), require(`./${file}`))
                })

                return [{ messages: messages.en }]
            }
        }
    }
}
```

This particular loader I've written allows me to load a structure like this, where the sub directories contain json that is flattened, the tree is implied by the path.

```
resources
└── lang
    ├── en
    │   ├── events.json
    │   ├── pages
    │   │   ├── app.json
    │   │   ├── assets.json
    │   │   ├── stats.json
    │   │   └── team.json
    │   ├── validation.json
    ├── en.json
    ├── ko
    │   └── validation.json
    └── ko.json
```

I'll add tests if you're happy with the implementation / naming / return      values - let me know if there are any tweaks I should make.

A future work that would be great is to wrap in multiple locale check support. I'm not sure how to even approach it – but it would certainly related to the loader function in the end.

I should note that this also addresses the issue I created last year https://github.com/kazupon/eslint-plugin-vue-i18n/issues/32 – by supplying the ability to use a custom loader function users could load js based locales, or any format they want.