### PR TITLE
docs: fix $t in example

### DIFF
--- a/docs/rules/no-raw-text.md
+++ b/docs/rules/no-raw-text.md
@@ -44,7 +44,7 @@ export default {
 ```js
 export default {
   // ✓ GOOD
-  template: `<p>{{ $('hello') }}</p>`
+  template: `<p>{{ $t('hello') }}</p>`
   // ...
 }
 ```


### PR DESCRIPTION
This PR replace `$t()` instead of `$()`