### PR TITLE
Change `no-missing-keys` and `no-dynamic-keys` rules to also verify keys used in the `<i18n-t>` component.

### DIFF
--- a/lib/rules/no-dynamic-keys.js
+++ b/lib/rules/no-dynamic-keys.js
@@ -56,7 +56,7 @@ function create (context) {
       checkDirective(context, node)
     },
 
-    'VElement[name=i18n] > VStartTag > VAttribute[directive=true] > VDirectiveKey' (node) {
+    'VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[directive=true] > VDirectiveKey' (node) {
       checkComponent(context, node)
     },
 

--- a/lib/rules/no-missing-keys.js
+++ b/lib/rules/no-missing-keys.js
@@ -18,11 +18,11 @@ function create (context) {
       checkDirective(context, node)
     },
 
-    "VElement[name=i18n] > VStartTag > VAttribute[key.name='path']" (node) {
+    "VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[key.name='path']" (node) {
       checkComponent(context, node)
     },
 
-    "VElement[name=i18n] > VStartTag > VAttribute[key.name.name='path']" (node) {
+    "VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[key.name.name='path']" (node) {
       checkComponent(context, node)
     },
 

--- a/tests/lib/rules/no-dynamic-keys.js
+++ b/tests/lib/rules/no-dynamic-keys.js
@@ -65,6 +65,14 @@ tester.run('no-dynamic-keys', rule, {
       `'missing' dynamic key is used'`
     ]
   }, {
+    // using <i18n-t> functional component in template block
+    code: `<template>
+      <i18n-t :path="missing"/>
+    </template>`,
+    errors: [
+      `'missing' dynamic key is used'`
+    ]
+  }, {
     // using custom directive in template block
     code: `<template>
       <p v-t="missing"></p>

--- a/tests/lib/rules/no-missing-keys.js
+++ b/tests/lib/rules/no-missing-keys.js
@@ -135,6 +135,17 @@ tester.run('no-missing-keys', rule, {
       `'missing' does not exist in 'ja'`
     ]
   }, {
+    // using <i18n-t> functional component in template block
+    code: `<template>
+      <div id="app">
+        <i18n-t path="missing"/>
+      </div>
+    </template>`,
+    errors: [
+      `'missing' does not exist in 'en'`,
+      `'missing' does not exist in 'ja'`
+    ]
+  }, {
     // nested basic
     code: `$t('missing.path')`,
     errors: [


### PR DESCRIPTION
Close #91 