### PR TITLE
Add TypeScript test case and add TypeScript FAQ to doc.

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -79,16 +79,28 @@ eslint "src/**/*.{js,vue,json}"
 # eslint "src/**/*.{js,vue,json5}"
 ```
 
-#### How to use custom parser?
+### How to use custom parser?
 
 If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [typescript-eslint-parser](https://www.npmjs.com/package/typescript-eslint-parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
+
+Also, `parserOptions` configured at the top level affect `.json` and `.yaml`. This plugin needs to use special parsers to parse `.json` and `.yaml`, so to correctly parse each extension, use the `overrides` option and overwrite the options again.
 
 ```diff
 - "parser": "babel-eslint",
   "parserOptions": {
 +     "parser": "babel-eslint",
       "sourceType": "module"
-  }
+  },
++ "overrides": [
++     {
++         "files": ["*.json", "*.json5"],
++         "extends": ["plugin:@intlify/vue-i18n/base"],
++     },
++     {
++         "files": ["*.yaml", "*.yml"],
++         "extends": ["plugin:@intlify/vue-i18n/base"],
++     }
++ ]
 ```
 
 ## :question: FAQ

--- a/lib/utils/collect-keys.ts
+++ b/lib/utils/collect-keys.ts
@@ -136,6 +136,8 @@ function collectKeyResourcesFromFiles(fileNames: string[]) {
   debug('collectKeysFromFiles', fileNames)
 
   const cliEngine = new CLIEngine({})
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  cliEngine.addPlugin('@intlify/vue-i18n', require('../index')) // for Test
 
   const results = []
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "docs": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "generate": "ts-node scripts/update.ts",
-    "lint": "eslint --ext js,ts lib scripts tests docs/.vuepress --ignore-pattern \"!.*\"",
+    "lint": "eslint --ext js,ts lib scripts tests/lib docs/.vuepress --ignore-pattern \"!.*\"",
     "lint:docs": "eslint --ext js,vue,md docs --ignore-pattern \"!.*\"",
     "release:prepare": "shipjs prepare",
     "release:trigger": "shipjs trigger",

--- a/tests/fixtures/no-unused-keys/invalid/typescript/.eslintrc.js
+++ b/tests/fixtures/no-unused-keys/invalid/typescript/.eslintrc.js
@@ -1,0 +1,32 @@
+module.exports = {
+  root: true,
+  extends: ['plugin:@intlify/vue-i18n/base'],
+  parserOptions: {
+    parser: '@typescript-eslint/parser'
+  },
+  rules: {
+    '@intlify/vue-i18n/no-unused-keys': ["error", {
+      "src": "./src",
+      "extensions": [".tsx", ".ts", ".vue"],
+      "enableFix": true,
+    }]
+  },
+  settings: {
+    'vue-i18n': {
+      localeDir: {
+        pattern: `./locales/*.{json,yaml,yml}`,
+        localeKey: 'file'
+      }
+    }
+  },
+  overrides: [
+    {
+      files: ['*.json', '*.json5'],
+      extends: ['plugin:@intlify/vue-i18n/base'],
+    },
+    {
+      files: ['*.yaml', '*.yml'],
+      extends: ['plugin:@intlify/vue-i18n/base'],
+    }
+  ]
+}

--- a/tests/fixtures/no-unused-keys/invalid/typescript/locales/en.json
+++ b/tests/fixtures/no-unused-keys/invalid/typescript/locales/en.json
@@ -1,0 +1,13 @@
+{
+  "hello": "hello world",
+  "messages": {
+    "hello": "hi DIO!",
+    "link": "@:message.hello",
+    "nested": {
+      "hello": "hi jojo!"
+    }
+  },
+  "hello_dio": "hello underscore DIO!",
+  "hello {name}": "hello {name}!",
+  "hello-dio": "hello hyphen DIO!"
+}

--- a/tests/fixtures/no-unused-keys/invalid/typescript/locales/ja.yaml
+++ b/tests/fixtures/no-unused-keys/invalid/typescript/locales/ja.yaml
@@ -1,0 +1,9 @@
+hello: "ハローワールド"
+messages:
+  hello: "こんにちは、DIO！"
+  link: "@:message.hello"
+  nested:
+    hello: "こんにちは、ジョジョ!"
+hello_dio: "こんにちは、アンダースコア DIO！"
+"hello {name}": "こんにちは、{name}！"
+hello-dio: "こんにちは、ハイフン DIO！"

--- a/tests/fixtures/no-unused-keys/invalid/typescript/src/App.vue
+++ b/tests/fixtures/no-unused-keys/invalid/typescript/src/App.vue
@@ -1,0 +1,14 @@
+<template>
+  <div id="app">
+    <p v-t="'hello_dio'">{{ $t('messages.hello') }}</p>
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'App' as const,
+  created() {
+    this.$i18n.t('hello {name}', { name: 'DIO' })
+  }
+}
+</script>

--- a/tests/fixtures/no-unused-keys/invalid/typescript/src/main.ts
+++ b/tests/fixtures/no-unused-keys/invalid/typescript/src/main.ts
@@ -1,0 +1,2 @@
+const $t = (a:any) => {}
+$t('hello')


### PR DESCRIPTION
I've found that using `parserOptions.parser` overwrites the `.json` and `.yaml` parsers and doesn't work correctly.
I added a workaround to the document to work around this issue and added a test case to make sure this works correctly.

refs #103