### PR TITLE
Add `no-duplicate-keys-in-locale` rule and change `no-missing-keys` rule to not report if there is one matching key in each locale

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -16,6 +16,7 @@
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
+| [@intlify/vue-i18n/<wbr>no-duplicate-keys-in-locale](./no-duplicate-keys-in-locale.html) | disallow duplicate localization keys within the same locale |  |
 | [@intlify/vue-i18n/<wbr>no-dynamic-keys](./no-dynamic-keys.html) | disallow localization dynamic keys at localization methods |  |
 | [@intlify/vue-i18n/<wbr>no-unused-keys](./no-unused-keys.html) | disallow unused localization keys | :black_nib: |
 

--- a/docs/rules/no-duplicate-keys-in-locale.md
+++ b/docs/rules/no-duplicate-keys-in-locale.md
@@ -1,0 +1,68 @@
+# @intlify/vue-i18n/no-duplicate-keys-in-locale
+
+> disallow duplicate localization keys within the same locale
+
+If you manage localization messages in multiple files, duplicate localization keys across multiple files can cause unexpected problems.
+
+## :book: Rule Details
+
+This rule reports duplicate localization keys within the same locale.
+
+:-1: Examples of **incorrect** code for this rule:
+
+locale messages:
+
+- `en.1.json`
+
+```json5
+// ✗ BAD
+{
+  "hello": "Hello! DIO!", // duplicate.
+  "hello": "Hello! DIO!", // duplicate.
+  "good-bye": "Good bye! DIO!"
+}
+```
+
+- `en.2.json`
+
+```json5
+// ✗ BAD
+{
+  "good-bye": "Good bye! DIO!" // This same key exists in `en.1.json`.
+}
+```
+
+:+1: Examples of **correct** code for this rule:
+
+locale messages:
+
+- `en.1.json`
+
+```json5
+// ✓ GOOD
+{
+  "hello": "Hello! DIO!",
+  "hi": "Hi! DIO!"
+}
+```
+
+- `en.2.json`
+
+```json5
+// ✓ GOOD
+{
+  "good-bye": "Good bye! DIO!" // This same key exists in `en.1.json`.
+}
+```
+
+## :gear: Options
+
+```json
+{
+  "@intlify/vue-i18n/no-duplicate-keys-in-locale": ["error", {
+    "ignoreI18nBlock": false
+  }]
+}
+```
+
+- `ignoreI18nBlock`: If `true`, do not report key duplication between `<i18n>` blocks and other files, it set to `false` as default.

--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -1,4 +1,5 @@
 /** DON'T EDIT THIS FILE; was created by scripts. */
+import noDuplicateKeysInLocale from './rules/no-duplicate-keys-in-locale'
 import noDynamicKeys from './rules/no-dynamic-keys'
 import noHtmlMessages from './rules/no-html-messages'
 import noMissingKeys from './rules/no-missing-keys'
@@ -7,6 +8,7 @@ import noUnusedKeys from './rules/no-unused-keys'
 import noVHtml from './rules/no-v-html'
 
 export = {
+  'no-duplicate-keys-in-locale': noDuplicateKeysInLocale,
   'no-dynamic-keys': noDynamicKeys,
   'no-html-messages': noHtmlMessages,
   'no-missing-keys': noMissingKeys,

--- a/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/lib/rules/no-duplicate-keys-in-locale.ts
@@ -1,0 +1,436 @@
+/**
+ * @author Yosuke Ota
+ */
+import type { AST as VAST } from 'vue-eslint-parser'
+import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as YAMLAST } from 'yaml-eslint-parser'
+import { extname } from 'path'
+import { getLocaleMessages } from '../utils/index'
+import debugBuilder from 'debug'
+import type { LocaleMessage } from '../utils/locale-messages'
+import type {
+  I18nLocaleMessageDictionary,
+  RuleContext,
+  RuleListener,
+  SourceCode
+} from '../types'
+import { joinPath } from '../utils/key-path'
+const debug = debugBuilder('eslint-plugin-vue-i18n:no-duplicate-keys-in-locale')
+
+interface DictData {
+  dict: I18nLocaleMessageDictionary
+  source: LocaleMessage
+}
+
+interface PathStack {
+  otherDictionaries: DictData[]
+  keyPath: string
+  locale: string | null
+  node?: JSONAST.JSONNode | YAMLAST.YAMLNode
+  upper?: PathStack
+}
+
+function getMessageFilepath(fullPath: string) {
+  if (fullPath.startsWith(process.cwd())) {
+    return fullPath.replace(process.cwd(), '.')
+  }
+  return fullPath
+}
+
+function create(context: RuleContext): RuleListener {
+  const filename = context.getFilename()
+  const options = (context.options && context.options[0]) || {}
+  const ignoreI18nBlock = Boolean(options.ignoreI18nBlock)
+
+  /**
+   * Create node visitor
+   */
+  function createVisitor<N extends JSONAST.JSONNode | YAMLAST.YAMLNode>(
+    targetLocaleMessage: LocaleMessage,
+    otherLocaleMessages: LocaleMessage[],
+    {
+      skipNode,
+      resolveKey,
+      resolveReportNode
+    }: {
+      skipNode: (node: N) => boolean
+      resolveKey: (node: N) => string | number | null
+      resolveReportNode: (node: N) => N
+    }
+  ) {
+    let pathStack: PathStack
+    if (targetLocaleMessage.localeKey === 'file') {
+      const locale = targetLocaleMessage.locales[0]
+      pathStack = {
+        keyPath: '',
+        locale,
+        otherDictionaries: otherLocaleMessages.map(lm => {
+          return {
+            dict: lm.getMessagesFromLocale(locale),
+            source: lm
+          }
+        })
+      }
+    } else {
+      pathStack = {
+        keyPath: '',
+        locale: null,
+        otherDictionaries: []
+      }
+    }
+    const existsKeyNodes: {
+      [locale: string]: { [key: string]: { node: N; reported: boolean }[] }
+    } = {}
+    const existsLocaleNodes: {
+      [key: string]: { node: N; reported: boolean }[]
+    } = {}
+    return {
+      enterNode(node: N) {
+        if (skipNode(node)) {
+          return
+        }
+
+        const key = resolveKey(node)
+        if (key == null) {
+          return
+        }
+        if (pathStack.locale == null) {
+          // locale is resolved
+          const locale = key as string
+          verifyDupeKey(existsLocaleNodes, locale, node)
+          pathStack = {
+            upper: pathStack,
+            node,
+            keyPath: '',
+            locale,
+            otherDictionaries: otherLocaleMessages.map(lm => {
+              return {
+                dict: lm.getMessagesFromLocale(locale),
+                source: lm
+              }
+            })
+          }
+          return
+        }
+        const keyOtherValues = pathStack.otherDictionaries
+          .filter(dict => dict.dict[key] != null)
+          .map(dict => {
+            return {
+              value: dict.dict[key],
+              source: dict.source
+            }
+          })
+        const keyPath = joinPath(pathStack.keyPath, key)
+        const nextOtherDictionaries: DictData[] = []
+        for (const value of keyOtherValues) {
+          if (typeof value.value === 'string') {
+            const reportNode = resolveReportNode(node)
+            context.report({
+              message: `duplicate key '${keyPath}' in '${
+                pathStack.locale
+              }'. "${getMessageFilepath(
+                value.source.fullpath
+              )}" has the same key`,
+              loc: reportNode.loc
+            })
+          } else {
+            nextOtherDictionaries.push({
+              dict: value.value,
+              source: value.source
+            })
+          }
+        }
+
+        verifyDupeKey(
+          existsKeyNodes[pathStack.locale] ||
+            (existsKeyNodes[pathStack.locale] = {}),
+          keyPath,
+          node
+        )
+
+        pathStack = {
+          upper: pathStack,
+          node,
+          keyPath,
+          locale: pathStack.locale,
+          otherDictionaries: nextOtherDictionaries
+        }
+      },
+      leaveNode(node: N) {
+        if (pathStack.node === node) {
+          pathStack = pathStack.upper!
+        }
+      }
+    }
+
+    function verifyDupeKey(
+      exists: {
+        [key: string]: { node: N; reported: boolean }[]
+      },
+      key: string,
+      node: N
+    ) {
+      const keyNodes = exists[key] || (exists[key] = [])
+      keyNodes.push({
+        node,
+        reported: false
+      })
+      if (keyNodes.length > 1) {
+        for (const keyNode of keyNodes.filter(e => !e.reported)) {
+          const reportNode = resolveReportNode(keyNode.node)
+          context.report({
+            message: `duplicate key '${key}'`,
+            loc: reportNode.loc
+          })
+          keyNode.reported = true
+        }
+      }
+    }
+  }
+  /**
+   * Create node visitor for JSON
+   */
+  function createVisitorForJson(
+    _sourceCode: SourceCode,
+    targetLocaleMessage: LocaleMessage,
+    otherLocaleMessages: LocaleMessage[]
+  ) {
+    return createVisitor<JSONAST.JSONNode>(
+      targetLocaleMessage,
+      otherLocaleMessages,
+      {
+        skipNode(node) {
+          if (
+            node.type === 'Program' ||
+            node.type === 'JSONExpressionStatement' ||
+            node.type === 'JSONProperty'
+          ) {
+            return true
+          }
+          const parent = node.parent!
+          if (parent.type === 'JSONProperty' && parent.key === node) {
+            return true
+          }
+          return false
+        },
+        resolveKey(node) {
+          const parent = node.parent!
+          if (parent.type === 'JSONProperty') {
+            return parent.key.type === 'JSONLiteral'
+              ? `${parent.key.value}`
+              : parent.key.name
+          } else if (parent.type === 'JSONArrayExpression') {
+            return parent.elements.indexOf(node as never)
+          }
+          return null
+        },
+
+        resolveReportNode(node) {
+          const parent = node.parent!
+          return parent.type === 'JSONProperty' ? parent.key : node
+        }
+      }
+    )
+  }
+
+  /**
+   * Create node visitor for YAML
+   */
+  function createVisitorForYaml(
+    sourceCode: SourceCode,
+    targetLocaleMessage: LocaleMessage,
+    otherLocaleMessages: LocaleMessage[]
+  ) {
+    const yamlKeyNodes = new Set()
+    return createVisitor<YAMLAST.YAMLNode>(
+      targetLocaleMessage,
+      otherLocaleMessages,
+      {
+        skipNode(node) {
+          if (
+            node.type === 'Program' ||
+            node.type === 'YAMLDocument' ||
+            node.type === 'YAMLDirective' ||
+            node.type === 'YAMLAnchor' ||
+            node.type === 'YAMLTag'
+          ) {
+            return true
+          }
+
+          if (node.type === 'YAMLPair') {
+            yamlKeyNodes.add(node.key)
+            return true
+          }
+          if (yamlKeyNodes.has(node)) {
+            // within key node
+            return true
+          }
+          const parent = node.parent
+          if (yamlKeyNodes.has(parent)) {
+            // within key node
+            yamlKeyNodes.add(node)
+            return true
+          }
+          return false
+        },
+        resolveKey(node) {
+          const parent = node.parent!
+          if (parent.type === 'YAMLPair' && parent.key) {
+            const key =
+              parent.key.type !== 'YAMLScalar'
+                ? sourceCode.getText(parent.key)
+                : parent.key.value
+            return typeof key === 'boolean' || key === null ? String(key) : key
+          } else if (parent.type === 'YAMLSequence') {
+            return parent.entries.indexOf(node as never)
+          }
+
+          return null
+        },
+        resolveReportNode(node) {
+          const parent = node.parent!
+          return parent.type === 'YAMLPair' ? parent.key || parent : node
+        }
+      }
+    )
+  }
+
+  if (extname(filename) === '.vue') {
+    return {
+      Program() {
+        const documentFragment =
+          context.parserServices.getDocumentFragment &&
+          context.parserServices.getDocumentFragment()
+        /** @type {VElement[]} */
+        const i18nBlocks =
+          (documentFragment &&
+            documentFragment.children.filter(
+              (node): node is VAST.VElement =>
+                node.type === 'VElement' && node.name === 'i18n'
+            )) ||
+          []
+        if (!i18nBlocks.length) {
+          return
+        }
+        const localeMessages = getLocaleMessages(context)
+
+        for (const block of i18nBlocks) {
+          if (
+            block.startTag.attributes.some(
+              attr => !attr.directive && attr.key.name === 'src'
+            )
+          ) {
+            continue
+          }
+
+          const targetLocaleMessage = localeMessages.findBlockLocaleMessage(
+            block
+          )
+          if (!targetLocaleMessage) {
+            continue
+          }
+          const sourceCode = targetLocaleMessage.getSourceCode()
+          if (!sourceCode) {
+            continue
+          }
+
+          const otherLocaleMessages: LocaleMessage[] = ignoreI18nBlock
+            ? []
+            : localeMessages.localeMessages.filter(
+                lm => lm !== targetLocaleMessage
+              )
+          const parserLang = targetLocaleMessage.getParserLang()
+
+          let visitor
+          if (parserLang === 'json') {
+            visitor = createVisitorForJson(
+              sourceCode,
+              targetLocaleMessage,
+              otherLocaleMessages
+            )
+          } else if (parserLang === 'yaml') {
+            visitor = createVisitorForYaml(
+              sourceCode,
+              targetLocaleMessage,
+              otherLocaleMessages
+            )
+          }
+
+          if (visitor == null) {
+            return
+          }
+
+          targetLocaleMessage.traverseNodes({
+            enterNode: visitor.enterNode,
+            leaveNode: visitor.leaveNode
+          })
+        }
+      }
+    }
+  } else if (context.parserServices.isJSON || context.parserServices.isYAML) {
+    const localeMessages = getLocaleMessages(context)
+    const targetLocaleMessage = localeMessages.findExistLocaleMessage(filename)
+    if (!targetLocaleMessage) {
+      debug(`ignore ${filename} in no-duplicate-keys-in-locale`)
+      return {}
+    }
+
+    const sourceCode = context.getSourceCode()
+    const otherLocaleMessages: LocaleMessage[] = localeMessages.localeMessages.filter(
+      lm => lm !== targetLocaleMessage
+    )
+
+    if (context.parserServices.isJSON) {
+      const { enterNode, leaveNode } = createVisitorForJson(
+        sourceCode,
+        targetLocaleMessage,
+        otherLocaleMessages
+      )
+
+      return {
+        '[type=/^JSON/]': enterNode,
+        '[type=/^JSON/]:exit': leaveNode
+      }
+    } else if (context.parserServices.isYAML) {
+      const { enterNode, leaveNode } = createVisitorForYaml(
+        sourceCode,
+        targetLocaleMessage,
+        otherLocaleMessages
+      )
+
+      return {
+        '[type=/^YAML/]': enterNode,
+        '[type=/^YAML/]:exit': leaveNode
+      }
+    }
+    return {}
+  } else {
+    debug(`ignore ${filename} in no-duplicate-keys-in-locale`)
+    return {}
+  }
+}
+
+export = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow duplicate localization keys within the same locale',
+      category: 'Best Practices',
+      recommended: false
+    },
+    fixable: null,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreI18nBlock: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+  create
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,6 +8,7 @@ import * as globSync from './utils/glob-sync'
 import * as globUtils from './utils/glob-utils'
 import * as ignoredPaths from './utils/ignored-paths'
 import * as index from './utils/index'
+import * as keyPath from './utils/key-path'
 import * as localeMessages from './utils/locale-messages'
 import * as parsers from './utils/parsers'
 import * as pathUtils from './utils/path-utils'
@@ -23,6 +24,7 @@ export = {
   'glob-utils': globUtils,
   'ignored-paths': ignoredPaths,
   index,
+  'key-path': keyPath,
   'locale-messages': localeMessages,
   parsers,
   'path-utils': pathUtils,

--- a/lib/utils/collect-keys.ts
+++ b/lib/utils/collect-keys.ts
@@ -232,9 +232,13 @@ export function collectKeysFromAST(
 }
 
 class UsedKeysCache {
-  private _targetFilesLoader: CacheLoader<[string[], string[]], string[]>
+  private _targetFilesLoader: CacheLoader<
+    [string[], string[], string],
+    string[]
+  >
   private _collectKeyResourcesFromFiles: (
-    fileNames: string[]
+    fileNames: string[],
+    cwd: string
   ) => ResourceLoader<string[]>[]
   constructor() {
     this._targetFilesLoader = new CacheLoader((files, extensions) => {
@@ -266,8 +270,9 @@ class UsedKeysCache {
    * @returns {ResourceLoader[]}
    */
   _getKeyResources(files: string[], extensions: string[]) {
-    const fileNames = this._targetFilesLoader.get(files, extensions)
-    return this._collectKeyResourcesFromFiles(fileNames)
+    const cwd = process.cwd()
+    const fileNames = this._targetFilesLoader.get(files, extensions, cwd)
+    return this._collectKeyResourcesFromFiles(fileNames, cwd)
   }
 }
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -103,10 +103,11 @@ export function getLocaleMessages(context: RuleContext): LocaleMessages {
 }
 
 class LocaleDirLocaleMessagesCache {
-  private _targetFilesLoader: CacheLoader<[string], string[]>
+  private _targetFilesLoader: CacheLoader<[string, string], string[]>
   private _loadLocaleMessages: (
     files: string[],
-    localeKey: LocaleKeyType
+    localeKey: LocaleKeyType,
+    cwd: string
   ) => FileLocaleMessage[]
   constructor() {
     this._targetFilesLoader = new CacheLoader(pattern => glob.sync(pattern))
@@ -120,17 +121,18 @@ class LocaleDirLocaleMessagesCache {
    * @returns {LocaleMessage[]}
    */
   getLocaleMessagesFromLocaleDir(localeDir: SettingsVueI18nLocaleDir) {
+    const cwd = process.cwd()
     const targetFilesLoader = this._targetFilesLoader
     let files
     let localeKey: LocaleKeyType
     if (typeof localeDir === 'string') {
-      files = targetFilesLoader.get(localeDir)
+      files = targetFilesLoader.get(localeDir, cwd)
       localeKey = 'file'
     } else {
-      files = targetFilesLoader.get(localeDir.pattern)
+      files = targetFilesLoader.get(localeDir.pattern, cwd)
       localeKey = String(localeDir.localeKey ?? 'file') as LocaleKeyType
     }
-    return this._loadLocaleMessages(files, localeKey)
+    return this._loadLocaleMessages(files, localeKey, cwd)
   }
 }
 

--- a/lib/utils/key-path.ts
+++ b/lib/utils/key-path.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Utility for localization keys
+ * @author Yosuke Ota
+ */
+export function joinPath(base: string, ...paths: (string | number)[]): string {
+  let result = base
+  for (const p of paths) {
+    if (typeof p === 'number') {
+      result += `[${p}]`
+    } else if (/^[^\s,.[\]]+$/iu.test(p)) {
+      result = result ? `${result}.${p}` : p
+    } else if (/^(?:0|[1-9]\d*)*$/iu.test(p)) {
+      result += `[${p}]`
+    } else {
+      result += `[${JSON.stringify(p)}]`
+    }
+  }
+  return result
+}

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "release:trigger": "shipjs trigger",
     "test": "mocha --require ts-node/register \"./tests/**/*.ts\"",
     "test:debug": "mocha --require ts-node/register --inspect \"./tests/**/*.ts\"",
-    "test:coverage": "nyc mocha --require ts-node/register ./tests/**/*.ts",
+    "test:coverage": "nyc mocha --require ts-node/register \"./tests/**/*.ts\"",
     "test:integrations": "mocha ./tests-integrations/*.js --timeout 60000"
   }
 }

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/locales/index.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/locales/index.1.json
@@ -1,0 +1,21 @@
+{
+  "en": {
+    "hello": "hello",
+    "messages": {
+      "foo": "foo",
+      "bar": "bar",
+      "baz": "baz",
+      "dupe": "dupe"
+    },
+    "dupe": "dupe"
+  },
+  "ja": {
+    "hello": "こんにちは",
+    "messages": {
+      "foo": "foo",
+      "bar": "bar",
+      "baz": "baz"
+    },
+    "dupe": "dupe"
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/locales/index.2.yaml
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/locales/index.2.yaml
@@ -1,0 +1,16 @@
+'en':
+  'good-bye': 'good bye'
+  'messages':
+    'qux': 'qux'
+    'quux': 'quux'
+    'corge': 'corge'
+    'dupe': 'dupe'
+  'dupe': 'dupe'
+'ja':
+  'good-bye': 'さようなら'
+  'messages':
+    'qux': 'qux'
+    'quux': 'quux'
+    'corge': 'corge'
+    'dupe': 'dupe'
+  'dupe': 'dupe'

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/src/App.vue
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/constructor-option-format/src/App.vue
@@ -1,0 +1,33 @@
+<i18n lang="yaml">
+en:
+  block: block
+  nest:
+    foo
+ja:
+  block: block
+  nest:
+    foo: bar
+</i18n>
+<i18n lang="yaml">
+en:
+  nest:
+    foo: bar
+ja:
+  dupe: dupe
+</i18n>
+<i18n lang="json">
+{
+  "en": {
+    "json-dupe": "dupe",
+    "nest": {
+      "json-dupe": "dupe"
+    },
+    "nest": {
+      "json-dupe": "dupe"
+    },
+    "json-dupe": "dupe"
+  }
+}
+</i18n>
+<template></template>
+<script></script>

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/en.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/en.1.json
@@ -1,0 +1,10 @@
+{
+  "hello": "hello",
+  "messages": {
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz",
+    "dupe": "dupe"
+  },
+  "dupe": "dupe"
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/en.2.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/en.2.json
@@ -1,0 +1,10 @@
+{
+  "good-bye": "good bye",
+  "messages": {
+    "qux": "qux",
+    "quux": "quux",
+    "corge": "corge",
+    "dupe": "dupe"
+  },
+  "dupe": "dupe"
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/ja.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/ja.1.json
@@ -1,0 +1,10 @@
+{
+  "hello": "こんにちは",
+  "messages": {
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz",
+    "dupe": "dupe"
+  },
+  "dupe": "dupe"
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/ja.2.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/locales/ja.2.json
@@ -1,0 +1,9 @@
+{
+  "good-bye": "さようなら",
+  "messages": {
+    "qux": "qux",
+    "quux": "quux",
+    "corge": "corge"
+  },
+  "dupe": "dupe"
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/src/App.vue
+++ b/tests/fixtures/no-duplicate-keys-in-locale/invalid/vue-cli-format/src/App.vue
@@ -1,0 +1,30 @@
+<i18n locale="en" lang="yaml">
+block: block
+nest:
+    foo: bar
+</i18n>
+<i18n locale="ja" lang="yaml">
+block: block
+nest:
+    foo: bar
+dupe: dupe
+</i18n>
+<i18n locale="en" lang="yaml">
+block: block
+nest:
+    foo: bar
+</i18n>
+<i18n locale="en" lang="json">
+{
+  "json-dupe": "dupe",
+  "nest": {
+    "json-dupe": "dupe"
+  },
+  "nest": {
+    "json-dupe": "dupe"
+  },
+  "json-dupe": "dupe"
+}
+</i18n>
+<template></template>
+<script></script>

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/locales/index.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/locales/index.1.json
@@ -1,0 +1,18 @@
+{
+  "en": {
+    "hello": "hello",
+    "messages": {
+      "foo": "foo",
+      "bar": "bar",
+      "baz": "baz"
+    }
+  },
+  "ja": {
+    "hello": "こんにちは",
+    "messages": {
+      "foo": "foo",
+      "bar": "bar",
+      "baz": "baz"
+    }
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/locales/index.2.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/locales/index.2.json
@@ -1,0 +1,18 @@
+{
+  "en": {
+    "good-bye": "good bye",
+    "messages": {
+      "qux": "qux",
+      "quux": "quux",
+      "corge": "corge"
+    }
+  },
+  "ja": {
+    "good-bye": "さようなら",
+    "messages": {
+      "qux": "qux",
+      "quux": "quux",
+      "corge": "corge"
+    }
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/src/App.vue
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/constructor-option-format/src/App.vue
@@ -1,0 +1,8 @@
+<i18n lang="yaml">
+en:
+  block: block
+ja:
+  block: block
+</i18n>
+<template></template>
+<script></script>

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/en.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/en.1.json
@@ -1,0 +1,8 @@
+{
+  "hello": "hello",
+  "messages": {
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz"
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/en.2.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/en.2.json
@@ -1,0 +1,8 @@
+{
+  "good-bye": "good bye",
+  "messages": {
+    "qux": "qux",
+    "quux": "quux",
+    "corge": "corge"
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/ja.1.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/ja.1.json
@@ -1,0 +1,8 @@
+{
+  "hello": "こんにちは",
+  "messages": {
+    "foo": "foo",
+    "bar": "bar",
+    "baz": "baz"
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/ja.2.json
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/locales/ja.2.json
@@ -1,0 +1,8 @@
+{
+  "good-bye": "さようなら",
+  "messages": {
+    "qux": "qux",
+    "quux": "quux",
+    "corge": "corge"
+  }
+}

--- a/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/src/App.vue
+++ b/tests/fixtures/no-duplicate-keys-in-locale/valid/vue-cli-format/src/App.vue
@@ -1,0 +1,8 @@
+<i18n locale="en" lang="yaml">
+block: block
+</i18n>
+<i18n locale="ja" lang="yaml">
+block: block
+</i18n>
+<template></template>
+<script></script>

--- a/tests/fixtures/no-missing-keys/constructor-option-format/locales/index.json
+++ b/tests/fixtures/no-missing-keys/constructor-option-format/locales/index.json
@@ -6,7 +6,8 @@
       "link": "@:message.hello",
       "nested": {
         "hello": "hi jojo!"
-      }
+      },
+      "en-only": "en-only"
     },
     "hello_dio": "hello underscore DIO!",
     "hello {name}": "hello {name}!",

--- a/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.2.json
+++ b/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.2.json
@@ -1,0 +1,5 @@
+{
+  "hello_dio": "hello underscore DIO!",
+  "hello {name}": "hello {name}!",
+  "hello-dio": "hello hyphen DIO!"
+}

--- a/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.json
+++ b/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.json
@@ -5,9 +5,7 @@
     "link": "@:message.hello",
     "nested": {
       "hello": "hi jojo!"
-    }
-  },
-  "hello_dio": "hello underscore DIO!",
-  "hello {name}": "hello {name}!",
-  "hello-dio": "hello hyphen DIO!"
+    },
+    "en-only": "en-only"
+  }
 }

--- a/tests/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/tests/lib/rules/no-duplicate-keys-in-locale.ts
@@ -1,0 +1,528 @@
+/**
+ * @author Yosuke Ota
+ */
+import { RuleTester } from 'eslint'
+import { join } from 'path'
+
+import rule = require('../../../lib/rules/no-duplicate-keys-in-locale')
+import { testOnFixtures } from '../test-utils'
+
+new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' }
+}).run('no-duplicate-keys-in-locale', rule as never, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <i18n locale="en">
+      {
+        "foo": "foo",
+        "bar": "bar"
+      }
+      </i18n>
+      <i18n locale="ja">
+      {
+        "foo": "foo",
+        "bar": "bar"
+      }
+      </i18n>
+      <template></template>
+      <script></script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <i18n>
+      {
+        "en": {
+          "foo": "foo",
+          "bar": "bar"
+        },
+        "ja": {
+          "foo": "foo",
+          "bar": "bar"
+        }
+      }
+      </i18n>
+      <template></template>
+      <script></script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <i18n locale="en" lang="yaml">
+      foo: foo
+      bar: bar
+      </i18n>
+      <i18n locale="ja" lang="yaml">
+      foo: foo
+      bar: bar
+      </i18n>
+      <template></template>
+      <script></script>`
+    }
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+      <i18n locale="en">
+      {
+        "foo": "foo",
+        "foo": "bar"
+      }
+      </i18n>
+      <i18n locale="ja">
+      {
+        "bar": "foo",
+        "bar": "bar"
+      }
+      </i18n>
+      <template></template>
+      <script>/*invalid*/</script>`,
+      errors: [
+        {
+          message: "duplicate key 'foo'",
+          line: 4
+        },
+        {
+          message: "duplicate key 'foo'",
+          line: 5
+        },
+        {
+          message: "duplicate key 'bar'",
+          line: 10
+        },
+        {
+          message: "duplicate key 'bar'",
+          line: 11
+        }
+      ]
+    }
+  ]
+})
+
+describe('no-duplicate-keys-in-locale with fixtures', () => {
+  const cwdRoot = join(__dirname, '../../fixtures/no-duplicate-keys-in-locale')
+
+  describe('valid', () => {
+    it('should be not detected dupe keys', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './valid/vue-cli-format'),
+          localeDir: `./locales/*.{json,yaml,yml}`,
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale'
+        },
+        {}
+      )
+    })
+
+    it('should be not detected dupe keys for constructor-option-format', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './valid/constructor-option-format'),
+          localeDir: {
+            pattern: `./locales/*.{json,yaml,yml}`,
+            localeKey: 'key'
+          },
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale'
+        },
+        {}
+      )
+    })
+  })
+
+  describe('invalid', () => {
+    it('should be detected dupe keys', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './invalid/vue-cli-format'),
+          localeDir: `./locales/*.{json,yaml,yml}`,
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale'
+        },
+        {
+          'locales/en.1.json': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/en.2.json\" has the same key"
+              },
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/en.2.json\" has the same key"
+              }
+            ]
+          },
+          'locales/en.2.json': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/en.1.json\" has the same key"
+              },
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/en.1.json\" has the same key"
+              }
+            ]
+          },
+          'locales/ja.1.json': {
+            errors: [
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.2.json\" has the same key"
+              }
+            ]
+          },
+          'locales/ja.2.json': {
+            errors: [
+              {
+                line: 8,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.1.json\" has the same key"
+              }
+            ]
+          },
+          'src/App.vue': {
+            errors: [
+              {
+                line: 2,
+                message:
+                  "duplicate key 'block' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 4,
+                message:
+                  "duplicate key 'nest.foo' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 10,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.1.json\" has the same key"
+              },
+              {
+                line: 10,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.2.json\" has the same key"
+              },
+              {
+                line: 13,
+                message:
+                  "duplicate key 'block' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 15,
+                message:
+                  "duplicate key 'nest.foo' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 19,
+                message: "duplicate key 'json-dupe'"
+              },
+              {
+                line: 20,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 21,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 23,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 24,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 26,
+                message: "duplicate key 'json-dupe'"
+              }
+            ]
+          }
+        }
+      )
+    })
+
+    it('should be detected dupe keys for constructor-option-format', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './invalid/constructor-option-format'),
+          localeDir: {
+            pattern: `./locales/*.{json,yaml,yml}`,
+            localeKey: 'key'
+          },
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale'
+        },
+        {
+          'locales/index.1.json': {
+            errors: [
+              {
+                line: 8,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/index.2.yaml\" has the same key"
+              },
+              {
+                line: 10,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/index.2.yaml\" has the same key"
+              },
+              {
+                line: 19,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.2.yaml\" has the same key"
+              }
+            ]
+          },
+          'locales/index.2.yaml': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/index.1.json\" has the same key"
+              },
+              {
+                line: 8,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/index.1.json\" has the same key"
+              },
+              {
+                line: 16,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.1.json\" has the same key"
+              }
+            ]
+          },
+          'src/App.vue': {
+            errors: [
+              {
+                line: 13,
+                message:
+                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 16,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.1.json\" has the same key"
+              },
+              {
+                line: 16,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.2.yaml\" has the same key"
+              },
+              {
+                line: 21,
+                message: "duplicate key 'json-dupe'"
+              },
+              {
+                line: 22,
+                message:
+                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 22,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 23,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 25,
+                message:
+                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
+              },
+              {
+                line: 25,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 26,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 28,
+                message: "duplicate key 'json-dupe'"
+              }
+            ]
+          }
+        }
+      )
+    })
+
+    it('should be detected dupe keys with ignoreI18nBlock', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './invalid/vue-cli-format'),
+          localeDir: `./locales/*.{json,yaml,yml}`,
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale',
+          options: [{ ignoreI18nBlock: true }]
+        },
+        {
+          'locales/en.1.json': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/en.2.json\" has the same key"
+              },
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/en.2.json\" has the same key"
+              }
+            ]
+          },
+          'locales/en.2.json': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/en.1.json\" has the same key"
+              },
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/en.1.json\" has the same key"
+              }
+            ]
+          },
+          'locales/ja.1.json': {
+            errors: [
+              {
+                line: 9,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.2.json\" has the same key"
+              }
+            ]
+          },
+          'locales/ja.2.json': {
+            errors: [
+              {
+                line: 8,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/ja.1.json\" has the same key"
+              }
+            ]
+          },
+          'src/App.vue': {
+            errors: [
+              {
+                line: 19,
+                message: "duplicate key 'json-dupe'"
+              },
+              {
+                line: 20,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 21,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 23,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 24,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 26,
+                message: "duplicate key 'json-dupe'"
+              }
+            ]
+          }
+        }
+      )
+    })
+
+    it('should be detected dupe keys with ignoreI18nBlock for constructor-option-format', () => {
+      testOnFixtures(
+        {
+          cwd: join(cwdRoot, './invalid/constructor-option-format'),
+          localeDir: {
+            pattern: `./locales/*.{json,yaml,yml}`,
+            localeKey: 'key'
+          },
+          ruleName: '@intlify/vue-i18n/no-duplicate-keys-in-locale',
+          options: [{ ignoreI18nBlock: true }]
+        },
+        {
+          'locales/index.1.json': {
+            errors: [
+              {
+                line: 8,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/index.2.yaml\" has the same key"
+              },
+              {
+                line: 10,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/index.2.yaml\" has the same key"
+              },
+              {
+                line: 19,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.2.yaml\" has the same key"
+              }
+            ]
+          },
+          'locales/index.2.yaml': {
+            errors: [
+              {
+                line: 7,
+                message:
+                  "duplicate key 'messages.dupe' in 'en'. \"./locales/index.1.json\" has the same key"
+              },
+              {
+                line: 8,
+                message:
+                  "duplicate key 'dupe' in 'en'. \"./locales/index.1.json\" has the same key"
+              },
+              {
+                line: 16,
+                message:
+                  "duplicate key 'dupe' in 'ja'. \"./locales/index.1.json\" has the same key"
+              }
+            ]
+          },
+          'src/App.vue': {
+            errors: [
+              {
+                line: 21,
+                message: "duplicate key 'json-dupe'"
+              },
+              {
+                line: 22,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 23,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 25,
+                message: "duplicate key 'nest'"
+              },
+              {
+                line: 26,
+                message: "duplicate key 'nest.json-dupe'"
+              },
+              {
+                line: 28,
+                message: "duplicate key 'json-dupe'"
+              }
+            ]
+          }
+        }
+      )
+    })
+  })
+})

--- a/tests/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/tests/lib/rules/no-duplicate-keys-in-locale.ts
@@ -322,12 +322,12 @@ describe('no-duplicate-keys-in-locale with fixtures', () => {
               },
               {
                 line: 22,
-                message:
-                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
+                message: "duplicate key 'nest'"
               },
               {
                 line: 22,
-                message: "duplicate key 'nest'"
+                message:
+                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
               },
               {
                 line: 23,
@@ -335,12 +335,12 @@ describe('no-duplicate-keys-in-locale with fixtures', () => {
               },
               {
                 line: 25,
-                message:
-                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
+                message: "duplicate key 'nest'"
               },
               {
                 line: 25,
-                message: "duplicate key 'nest'"
+                message:
+                  "duplicate key 'nest' in 'en'. \"./src/App.vue\" has the same key"
               },
               {
                 line: 26,

--- a/tests/lib/rules/no-missing-keys.ts
+++ b/tests/lib/rules/no-missing-keys.ts
@@ -210,6 +210,10 @@ tester.run('no-missing-keys', rule as never, {
           `'messages.missing' does not exist in 'en'`,
           `'messages.missing' does not exist in 'ja'`
         ]
+      },
+      {
+        code: `$t('messages.en-only')`,
+        errors: ["'messages.en-only' does not exist in 'ja'"]
       }
     ],
     [

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -1,6 +1,14 @@
 import fs from 'fs'
 import path from 'path'
+import assert from 'assert'
+import { CLIEngine } from 'eslint'
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import linter = require('eslint/lib/linter')
 import base = require('../../lib/configs/base')
+import plugin = require('../../lib/index')
+import { SettingsVueI18nLocaleDir } from '../../lib/types'
+const { SourceCodeFixer } = linter
 
 function buildBaseConfigPath() {
   const configPath = path.join(
@@ -13,3 +21,191 @@ function buildBaseConfigPath() {
 }
 
 export const baseConfigPath = buildBaseConfigPath()
+
+export function testOnFixtures(
+  testOptions: {
+    cwd: string
+    ruleName: string
+  } & (
+    | {
+        localeDir?: SettingsVueI18nLocaleDir
+        options?: unknown[]
+        useEslintrc?: false
+      }
+    | {
+        useEslintrc: true
+      }
+  ),
+  expectedMessages: {
+    [file: string]: {
+      output?: string | null
+      errors:
+        | string[]
+        | {
+            message: string
+            line: number
+            suggestions?: { desc: string; output: string }[]
+          }[]
+    }
+  },
+  assertOptions?: { messageOnly?: boolean }
+): void {
+  const originalCwd = process.cwd()
+  try {
+    process.chdir(testOptions.cwd)
+    const linter = new CLIEngine(
+      testOptions.useEslintrc
+        ? {
+            cwd: testOptions.cwd,
+            useEslintrc: true
+          }
+        : {
+            cwd: testOptions.cwd,
+            baseConfig: {
+              extends: [baseConfigPath],
+              settings: {
+                'vue-i18n': {
+                  localeDir: testOptions.localeDir
+                }
+              }
+            },
+            useEslintrc: false,
+            parserOptions: {
+              ecmaVersion: 2020,
+              sourceType: 'module'
+            },
+            rules: {
+              [testOptions.ruleName]: ['error', ...(testOptions.options || [])]
+            },
+            extensions: ['.js', '.vue', '.json', '.json5', '.yaml', '.yml']
+          }
+    )
+    linter.addPlugin('@intlify/vue-i18n', plugin)
+
+    const messages = linter.executeOnFiles(['.'])
+    const filePaths = Object.keys(expectedMessages).map(file =>
+      path.join(testOptions.cwd, file)
+    )
+    for (const lintResult of messages.results) {
+      if (lintResult.errorCount > 0) {
+        if (!filePaths.includes(lintResult.filePath)) {
+          assert.fail(
+            'Expected ' +
+              lintResult.filePath.replace(testOptions.cwd, '') +
+              ' values are required.'
+          )
+        }
+      }
+    }
+
+    let count = 0
+    for (const filePath of Object.keys(expectedMessages)) {
+      const fileMessages = getResult(
+        testOptions.ruleName,
+        messages,
+        path.resolve(testOptions.cwd, filePath),
+        assertOptions
+      )
+
+      assert.strictEqual(
+        stringify(fileMessages),
+        stringify(expectedMessages[filePath]),
+        'Unexpected messages in ' + filePath
+      )
+      count += fileMessages.errors.length
+    }
+    assert.equal(messages.errorCount, count)
+  } finally {
+    process.chdir(originalCwd)
+  }
+}
+
+function getResult(
+  ruleName: string,
+  messages: CLIEngine.LintReport,
+  fullPath: string,
+  options?: { messageOnly?: boolean }
+): {
+  output?: string
+  errors:
+    | string[]
+    | {
+        message: string
+        line: number
+        suggestions?: { desc: string; output: string }[]
+      }[]
+} {
+  const result = messages.results.find(result => result.filePath === fullPath)
+  if (!result) {
+    assert.fail('not found lint results at ' + fullPath)
+  }
+  const messageOnly = options?.messageOnly ?? false
+  if (messageOnly) {
+    return {
+      errors: result.messages.map(message => {
+        assert.equal(message.ruleId, ruleName)
+        return message.message
+      })
+    }
+  }
+  const rule =
+    plugin.rules[
+      ruleName.replace(/^@intlify\/vue-i18n\//u, '') as 'no-unused-keys'
+    ]
+  return {
+    ...(rule.meta.fixable != null
+      ? {
+          output: (() => {
+            const output = SourceCodeFixer.applyFixes(
+              result.source,
+              result.messages
+            ).output
+            return output === result.source ? null : output
+          })()
+        }
+      : {}),
+    errors: result.messages.map(message => {
+      assert.equal(message.ruleId, ruleName)
+
+      return {
+        message: message.message,
+        line: message.line,
+        ...(message.suggestions
+          ? {
+              suggestions: message.suggestions!.map(suggest => {
+                const output = SourceCodeFixer.applyFixes(result.source, [
+                  suggest
+                ]).output
+                return {
+                  desc: suggest.desc,
+                  output
+                }
+              })
+            }
+          : {})
+      }
+    })
+  }
+}
+
+function stringify(obj: unknown) {
+  return JSON.stringify(sortKeysObject(obj), null, 2)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sortKeysObject(obj: any): unknown {
+  if (obj == null) {
+    return obj
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sortKeysObject)
+  }
+  if (typeof obj !== 'object') {
+    return obj
+  }
+  const res: { [key: string]: unknown } = {}
+  for (const key of Object.keys(obj).sort()) {
+    res[key] = sortKeysObject(obj[key])
+  }
+  return res
+}


### PR DESCRIPTION
This PR makes the following two changes.

- Adds `no-duplicate-keys-in-locale` rule that reports duplicate localization keys within the same locale.
- Changes `no-missing-keys` rule to not report if there is one matching key in each locale.

close #104