### PR TITLE
Fix false positives when key contains object in YAML in `no-unused-keys` and `no-duplicate-keys-in-locale` rules.

### DIFF
--- a/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/lib/rules/no-duplicate-keys-in-locale.ts
@@ -257,10 +257,6 @@ function create(context: RuleContext): RuleListener {
             return true
           }
 
-          if (node.type === 'YAMLPair') {
-            yamlKeyNodes.add(node.key)
-            return true
-          }
           if (yamlKeyNodes.has(node)) {
             // within key node
             return true
@@ -269,6 +265,10 @@ function create(context: RuleContext): RuleListener {
           if (yamlKeyNodes.has(parent)) {
             // within key node
             yamlKeyNodes.add(node)
+            return true
+          }
+          if (node.type === 'YAMLPair') {
+            yamlKeyNodes.add(node.key)
             return true
           }
           return false

--- a/lib/rules/no-unused-keys.ts
+++ b/lib/rules/no-unused-keys.ts
@@ -321,10 +321,6 @@ function create(context: RuleContext): RuleListener {
           return true
         }
 
-        if (node.type === 'YAMLPair') {
-          yamlKeyNodes.add(node.key)
-          return true
-        }
         if (yamlKeyNodes.has(node)) {
           // within key node
           return true
@@ -333,6 +329,10 @@ function create(context: RuleContext): RuleListener {
         if (yamlKeyNodes.has(parent)) {
           // within key node
           yamlKeyNodes.add(node)
+          return true
+        }
+        if (node.type === 'YAMLPair') {
+          yamlKeyNodes.add(node.key)
           return true
         }
         return false

--- a/tests/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/tests/lib/rules/no-duplicate-keys-in-locale.ts
@@ -61,6 +61,18 @@ new RuleTester({
       </i18n>
       <template></template>
       <script></script>`
+    },
+    {
+      filename: 'test.vue',
+      code: `
+      <i18n lang="yaml">
+      en:
+        ? [{foo: {bar: baz}}]
+        : 123
+        foo: {bar: baz}
+      </i18n>
+      <template></template>
+      <script></script>`
     }
   ],
   invalid: [

--- a/tests/lib/rules/no-unused-keys.ts
+++ b/tests/lib/rules/no-unused-keys.ts
@@ -910,6 +910,17 @@ ${' '.repeat(6)}
           ]
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `
+    <i18n locale="en" lang="yaml">
+    ? [{foo: bar}]
+    : {foo: bar}
+    </i18n>
+    <template></template>
+    <script></script>`,
+      errors: [`unused '["[{foo: bar}]"].foo' key`]
     }
   ]
 })


### PR DESCRIPTION
This PR fixes false positives when the key contains objects, like in the following YAML.


```yaml
? {foo: bar}
: value
```