### PR TITLE
Replace from eslint-plugin-jsonc to jsonc-eslint-parser.

### DIFF
--- a/lib/configs/base.ts
+++ b/lib/configs/base.ts
@@ -8,7 +8,7 @@ export = {
       // see https://github.com/vuejs/eslint-plugin-vue/pull/1262
       parser: require.resolve('vue-eslint-parser'),
       parserOptions: {
-        parser: require.resolve('eslint-plugin-jsonc')
+        parser: require.resolve('jsonc-eslint-parser')
       }
     },
     {

--- a/lib/rules/no-duplicate-keys-in-locale.ts
+++ b/lib/rules/no-duplicate-keys-in-locale.ts
@@ -2,7 +2,7 @@
  * @author Yosuke Ota
  */
 import type { AST as VAST } from 'vue-eslint-parser'
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import { extname } from 'path'
 import { getLocaleMessages } from '../utils/index'

--- a/lib/rules/no-html-messages.ts
+++ b/lib/rules/no-html-messages.ts
@@ -6,7 +6,7 @@ import parse5 from 'parse5'
 import { getLocaleMessages } from '../utils/index'
 import debugBuilder from 'debug'
 import type { AST as VAST } from 'vue-eslint-parser'
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import type { RuleContext, RuleListener } from '../types'
 

--- a/lib/rules/no-unused-keys.ts
+++ b/lib/rules/no-unused-keys.ts
@@ -2,7 +2,7 @@
  * @author kazuya kawaguchi (a.k.a. kazupon)
  */
 import type { AST as VAST } from 'vue-eslint-parser'
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import { extname } from 'path'
 import { collectKeysFromAST, usedKeysCache } from '../utils/collect-keys'

--- a/lib/types/eslint.ts
+++ b/lib/types/eslint.ts
@@ -1,4 +1,4 @@
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import type { AST as VAST } from 'vue-eslint-parser'
 import type { VueParserServices } from './vue-parser-services'

--- a/lib/utils/locale-messages.ts
+++ b/lib/utils/locale-messages.ts
@@ -2,7 +2,7 @@
  * @fileoverview Classes that acquires and manages localization messages
  * @author Yosuke Ota
  */
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import type { AST as VAST } from 'vue-eslint-parser'
 import type {

--- a/lib/utils/parsers/index.ts
+++ b/lib/utils/parsers/index.ts
@@ -2,12 +2,12 @@
  * @fileoverview parser for <i18n> block
  * @author Yosuke Ota
  */
-import type { AST as JSONAST } from 'eslint-plugin-jsonc'
+import type { AST as JSONAST } from 'jsonc-eslint-parser'
 import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import {
   parseForESLint as parseJsonForESLint,
   getStaticJSONValue
-} from 'eslint-plugin-jsonc'
+} from 'jsonc-eslint-parser'
 import {
   parseForESLint as parseYamlForESLint,
   getStaticYAMLValue
@@ -203,21 +203,14 @@ export function parseJsonInI18nBlock(
   context: RuleContext,
   i18nBlock: VAST.VElement
 ): JSONParsed | null {
-  const result = parseInI18nBlock(
-    context,
-    i18nBlock,
-    (parseJsonForESLint as never) as (
-      code: string,
-      option: unknown
-    ) => { ast: JSONAST.JSONProgram; visitorKeys: VisitorKeys }
-  )
+  const result = parseInI18nBlock(context, i18nBlock, parseJsonForESLint)
   if (result == null) {
     return result
   }
   return {
     lang: 'json',
     getStaticValue(node: JSONAST.JSONNode): I18nLocaleMessageDictionary {
-      return getStaticJSONValue(node as never) as never
+      return getStaticJSONValue(node) as never
     },
     ...result
   }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     }
   },
   "dependencies": {
-    "eslint-plugin-jsonc": "^0.4.0",
     "fast-diff": "^1.2.0",
     "glob": "^7.1.3",
     "ignore": "^5.0.5",
     "js-yaml": "^3.14.0",
     "json5": "^2.1.3",
+    "jsonc-eslint-parser": "^0.5.2",
     "lodash": "^4.17.11",
     "parse5": "^6.0.0",
     "vue-eslint-parser": "^7.0.0",

--- a/tests-integrations/config-recommended/.eslintrc.js
+++ b/tests-integrations/config-recommended/.eslintrc.js
@@ -2,11 +2,7 @@
 
 module.exports = {
   root: true,
-  extends: [
-    'plugin:vue/recommended',
-    'plugin:jsonc/recommended-with-jsonc',
-    'plugin:@intlify/vue-i18n/recommended'
-  ],
+  extends: ['plugin:vue/recommended', 'plugin:@intlify/vue-i18n/recommended'],
   settings: {
     'vue-i18n': {
       localeDir: `./src/resources/*.json`

--- a/tests-integrations/config-recommended/yarn.lock
+++ b/tests-integrations/config-recommended/yarn.lock
@@ -24,15 +24,18 @@
     js-tokens "^4.0.0"
 
 "@intlify/eslint-plugin-vue-i18n@file:../..":
-  version "0.6.0"
+  version "0.8.1"
   dependencies:
-    eslint-plugin-jsonc "^0.3.1"
     fast-diff "^1.2.0"
     glob "^7.1.3"
     ignore "^5.0.5"
+    js-yaml "^3.14.0"
+    json5 "^2.1.3"
+    jsonc-eslint-parser "^0.5.2"
     lodash "^4.17.11"
     parse5 "^6.0.0"
     vue-eslint-parser "^7.0.0"
+    yaml-eslint-parser "^0.0.8"
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -48,6 +51,11 @@ acorn@^7.1.1, acorn@^7.2.0:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
+
+acorn@^7.3.1:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
+  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
 
 ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.3"
@@ -210,11 +218,6 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-plugin-jsonc@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-0.3.1.tgz#363b3516ce57a4ef49b8149f108837a3151c06a0"
-  integrity sha512-MkvmvKv4WYrxYMds0LjzC+rn+g4EpGIs1xLYeZeULSK/m90CxKPHrsKKnEMyp+bXVTU2WgBV/d8xIpEHTJWbUw==
-
 eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
@@ -230,7 +233,7 @@ eslint-utils@^2.0.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -276,6 +279,15 @@ eslint@^7.4.0:
     table "^5.2.3"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+"espree@^6.0.0 || ^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
+  integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
+  dependencies:
+    acorn "^7.3.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.3.0"
 
 espree@^6.2.1:
   version "6.2.1"
@@ -479,7 +491,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
@@ -497,6 +509,21 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json5@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
+jsonc-eslint-parser@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-0.5.2.tgz#b195bb21cc81c466724da5c1d4368d25807fb3ac"
+  integrity sha512-TNtw6VVL1dS95FbMQTvv6I6OjaEORW9mH4OdN07VSDt8TAO7G7ZQEfSMf1p0+hC0tKZLtMmU6wZZmpPcupmGrg==
+  dependencies:
+    eslint-visitor-keys "^1.3.0"
+    espree "^6.0.0 || ^7.2.0"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -504,6 +531,11 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.19"
@@ -700,6 +732,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+tslib@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -759,3 +796,26 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+yaml-eslint-parser@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/yaml-eslint-parser/-/yaml-eslint-parser-0.0.8.tgz#9bf30c1433e27fe47524509f087df1501f6d55ea"
+  integrity sha512-VefMCl1P4St+PUBaGPRtZEwZowOGaALufuOuQs+3hUaut5X6ReTfUqIXQY3TJ/L3WkuugpnvzNdpCVu0WbgeeQ==
+  dependencies:
+    eslint-visitor-keys "^1.3.0"
+    yaml "^1.10.0"
+    yaml-unist-parser "^1.2.1"
+
+yaml-unist-parser@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/yaml-unist-parser/-/yaml-unist-parser-1.3.0.tgz#f64f1af96171fe4d7eb462e94225d42a6009b60e"
+  integrity sha512-kF1OS6fi9BzqX+vVC5hp+R5mmrHLH4f19Nx8fAwb08VqUwgFDBPOOu24VZO06nSOur13CGUTgHuaw5RIzpRnCw==
+  dependencies:
+    lines-and-columns "^1.1.6"
+    tslib "^1.10.0"
+    yaml "^1.10.0"
+
+yaml@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
+  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,6 +1730,11 @@ acorn@^7.2.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
+acorn@^7.3.1:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
+  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+
 add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
@@ -4211,14 +4216,6 @@ eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-jsonc@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-0.4.0.tgz#c471f7dc1c8d4c3798ef7eeee67066c14384bb52"
-  integrity sha512-pWSpv2aXBeXAal4hYgn+jfWTwEmypMdPV9AQMs19QLXNPvOoJ23mWMAxCV+aU5xyuH28ME12qeiM1BpeGZxDrg==
-  dependencies:
-    eslint-utils "^2.1.0"
-    natural-compare "^1.4.0"
-
 eslint-plugin-markdown@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.1.tgz#9705786310f84dad9cf800bea1eb5c4acafcc13a"
@@ -4274,7 +4271,7 @@ eslint-scope@^5.1.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.0.0, eslint-utils@^2.1.0:
+eslint-utils@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -4346,6 +4343,15 @@ espree@^4.1.0:
     acorn "^6.0.2"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+"espree@^6.0.0 || ^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
+  integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
+  dependencies:
+    acorn "^7.3.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.3.0"
 
 espree@^6.1.2:
   version "6.1.2"
@@ -6309,6 +6315,14 @@ json5@^2.1.2, json5@^2.1.3:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
+
+jsonc-eslint-parser@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-0.5.2.tgz#b195bb21cc81c466724da5c1d4368d25807fb3ac"
+  integrity sha512-TNtw6VVL1dS95FbMQTvv6I6OjaEORW9mH4OdN07VSDt8TAO7G7ZQEfSMf1p0+hC0tKZLtMmU6wZZmpPcupmGrg==
+  dependencies:
+    eslint-visitor-keys "^1.3.0"
+    espree "^6.0.0 || ^7.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR replaces the JSON parser from eslint-plugin-jsonc to jsonc-eslint-parser.

Previously, eslint-plugin-jsonc had both the ESLint plugin module and the JSON parser module, but now the parser is separated as the jsonc-eslint-parser package.

With this change, it will not be affected by the version upgrade that updated only the rules of eslint-plugin-jsonc.

