### PR TITLE
docs: Fix typo and dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please make sure to read the [Issue Reporting Checklist](https://github.com/intl
 
 ## :muscle: Contribution
 
-Please make sure to read the [Contributing Guide](https://github.com/intlify/eslint-plugin-vue-i18n/blob/master/CONTRIBUTING.md) before making a pull request.
+Please make sure to read the [Contributing Guide](https://github.com/intlify/eslint-plugin-vue-i18n/blob/master/.github/CONTRIBUTING.md) before making a pull request.
 
 ## :copyright: License
 

--- a/docs/started.md
+++ b/docs/started.md
@@ -38,7 +38,7 @@ module.export = {
   },
   settings: {
     'vue-i18n': {
-      localeDir: './path/to/locales/*.{json,json5,yaml,yml}}' // extension is glob formatting!
+      localeDir: './path/to/locales/*.{json,json5,yaml,yml}' // extension is glob formatting!
       // or
       // localeDir: {
       //   pattern: './path/to/locales/*.{json,json5,yaml,yml}', // extension is glob formatting!


### PR DESCRIPTION
This PR is fix typo in document and dead link in `README.md`