### PR TITLE
Chores: Update eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,8 @@ module.exports = {
         parser: '@typescript-eslint/parser'
       },
       rules: {
-        '@typescript-eslint/no-non-null-assertion': 'off'
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/consistent-type-imports': 'error'
       }
     }
   ]

--- a/lib/types/eslint.ts
+++ b/lib/types/eslint.ts
@@ -3,7 +3,7 @@ import type { AST as YAMLAST } from 'yaml-eslint-parser'
 import type { AST as VAST } from 'vue-eslint-parser'
 import type { VueParserServices } from './vue-parser-services'
 import type { TokenStore } from './types'
-import { SettingsVueI18nLocaleDir } from './settings'
+import type { SettingsVueI18nLocaleDir } from './settings'
 
 export interface Position {
   /** >= 1 */

--- a/lib/types/nodes.ts
+++ b/lib/types/nodes.ts
@@ -1,4 +1,4 @@
-import { MaybeNode } from './eslint'
+import type { MaybeNode } from './eslint'
 
 export interface JSXText extends MaybeNode {
   type: 'JSXText'

--- a/lib/types/vue-parser-services.ts
+++ b/lib/types/vue-parser-services.ts
@@ -2,7 +2,7 @@ import type { Rule } from 'eslint'
 import type { RuleContext } from './eslint'
 import type { AST as VAST } from 'vue-eslint-parser'
 import type { TokenStore } from './types'
-import { VElement } from 'vue-eslint-parser/ast'
+import type { VElement } from 'vue-eslint-parser/ast'
 
 export interface TemplateListener {
   [key: string]: ((node: never) => void) | undefined

--- a/lib/utils/cache-function.ts
+++ b/lib/utils/cache-function.ts
@@ -3,7 +3,8 @@
  * @author Yosuke Ota
  */
 
-import { CacheLoader, LoadData } from './cache-loader'
+import type { LoadData } from './cache-loader'
+import { CacheLoader } from './cache-loader'
 
 /**
  * This function returns a function that returns the result value that was called for the given function.

--- a/lib/utils/glob-sync.ts
+++ b/lib/utils/glob-sync.ts
@@ -5,7 +5,8 @@
  * @author kazuya kawaguchi (a.k.a. kazupon)
  */
 
-import { GlobSync as Sync, IOptions, IGlobBase } from 'glob'
+import type { IOptions, IGlobBase } from 'glob'
+import { GlobSync as Sync } from 'glob'
 import { inherits } from 'util'
 
 const IGNORE = Symbol('ignore')

--- a/lib/utils/ignored-paths.ts
+++ b/lib/utils/ignored-paths.ts
@@ -7,7 +7,8 @@
 import { existsSync, statSync, readFileSync } from 'fs'
 import { resolve, dirname, relative, sep } from 'path'
 import { getRelativePath } from './path-utils'
-import ignore, { Ignore } from 'ignore'
+import type { Ignore } from 'ignore'
+import ignore from 'ignore'
 import debugBuilder from 'debug'
 const debug = debugBuilder('eslint-plugin-vue-i18n:ignored-paths')
 

--- a/scripts/update-docs-index.ts
+++ b/scripts/update-docs-index.ts
@@ -5,7 +5,8 @@
  */
 import { writeFileSync } from 'fs'
 import { resolve } from 'path'
-import { withCategories, RuleInfo } from './lib/rules'
+import type { RuleInfo } from './lib/rules'
+import { withCategories } from './lib/rules'
 
 function toTableRow(rule: RuleInfo) {
   const mark = `${rule.recommended ? ':star:' : ''}${

--- a/tests/lib/rules/key-format-style.ts
+++ b/tests/lib/rules/key-format-style.ts
@@ -4,7 +4,7 @@
 import { join } from 'path'
 import { RuleTester } from 'eslint'
 import rule = require('../../../lib/rules/key-format-style')
-import { SettingsVueI18nLocaleDirObject } from '../../../lib/types'
+import type { SettingsVueI18nLocaleDirObject } from '../../../lib/types'
 
 const vueParser = require.resolve('vue-eslint-parser')
 const jsonParser = require.resolve('jsonc-eslint-parser')

--- a/tests/lib/test-utils.ts
+++ b/tests/lib/test-utils.ts
@@ -7,7 +7,7 @@ import { CLIEngine } from 'eslint'
 import linter = require('eslint/lib/linter')
 import base = require('../../lib/configs/base')
 import plugin = require('../../lib/index')
-import { SettingsVueI18nLocaleDir } from '../../lib/types'
+import type { SettingsVueI18nLocaleDir } from '../../lib/types'
 const { SourceCodeFixer } = linter
 
 function buildBaseConfigPath() {


### PR DESCRIPTION
This PR modifies the eslint configuration so that this project uses the `@typescript-eslint/consistent-type-imports` rule.