### PR TITLE
Add no-deprecated-i18n-component rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -5,13 +5,14 @@
 
 ## Recommended
 
-| Rule ID                                                                    | Description                                                          |        |
-| :------------------------------------------------------------------------- | :------------------------------------------------------------------- | :----- |
-| [@intlify/vue-i18n/<wbr>no-html-messages](./no-html-messages.html)         | disallow use HTML localization messages                              | :star: |
-| [@intlify/vue-i18n/<wbr>no-missing-keys](./no-missing-keys.html)           | disallow missing locale message key at localization methods          | :star: |
-| [@intlify/vue-i18n/<wbr>no-raw-text](./no-raw-text.html)                   | disallow to string literal in template or JSX                        | :star: |
-| [@intlify/vue-i18n/<wbr>no-v-html](./no-v-html.html)                       | disallow use of localization methods on v-html to prevent XSS attack | :star: |
-| [@intlify/vue-i18n/<wbr>valid-message-syntax](./valid-message-syntax.html) | disallow invalid message syntax                                      |        |
+| Rule ID                                                                                    | Description                                                          |             |
+| :----------------------------------------------------------------------------------------- | :------------------------------------------------------------------- | :---------- |
+| [@intlify/vue-i18n/<wbr>no-deprecated-i18n-component](./no-deprecated-i18n-component.html) | disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)   | :black_nib: |
+| [@intlify/vue-i18n/<wbr>no-html-messages](./no-html-messages.html)                         | disallow use HTML localization messages                              | :star:      |
+| [@intlify/vue-i18n/<wbr>no-missing-keys](./no-missing-keys.html)                           | disallow missing locale message key at localization methods          | :star:      |
+| [@intlify/vue-i18n/<wbr>no-raw-text](./no-raw-text.html)                                   | disallow to string literal in template or JSX                        | :star:      |
+| [@intlify/vue-i18n/<wbr>no-v-html](./no-v-html.html)                                       | disallow use of localization methods on v-html to prevent XSS attack | :star:      |
+| [@intlify/vue-i18n/<wbr>valid-message-syntax](./valid-message-syntax.html)                 | disallow invalid message syntax                                      |             |
 
 ## Best Practices
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -5,27 +5,30 @@
 
 ## Recommended
 
-| Rule ID                                                                                    | Description                                                          |             |
-| :----------------------------------------------------------------------------------------- | :------------------------------------------------------------------- | :---------- |
-| [@intlify/vue-i18n/<wbr>no-deprecated-i18n-component](./no-deprecated-i18n-component.html) | disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)   | :black_nib: |
-| [@intlify/vue-i18n/<wbr>no-html-messages](./no-html-messages.html)                         | disallow use HTML localization messages                              | :star:      |
-| [@intlify/vue-i18n/<wbr>no-missing-keys](./no-missing-keys.html)                           | disallow missing locale message key at localization methods          | :star:      |
-| [@intlify/vue-i18n/<wbr>no-raw-text](./no-raw-text.html)                                   | disallow to string literal in template or JSX                        | :star:      |
-| [@intlify/vue-i18n/<wbr>no-v-html](./no-v-html.html)                                       | disallow use of localization methods on v-html to prevent XSS attack | :star:      |
-| [@intlify/vue-i18n/<wbr>valid-message-syntax](./valid-message-syntax.html)                 | disallow invalid message syntax                                      |             |
+<!--prettier-ignore-->
+| Rule ID | Description |    |
+|:--------|:------------|:---|
+| [@intlify/vue-i18n/<wbr>no-deprecated-i18n-component](./no-deprecated-i18n-component.html) | disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+) | :black_nib: |
+| [@intlify/vue-i18n/<wbr>no-html-messages](./no-html-messages.html) | disallow use HTML localization messages | :star: |
+| [@intlify/vue-i18n/<wbr>no-missing-keys](./no-missing-keys.html) | disallow missing locale message key at localization methods | :star: |
+| [@intlify/vue-i18n/<wbr>no-raw-text](./no-raw-text.html) | disallow to string literal in template or JSX | :star: |
+| [@intlify/vue-i18n/<wbr>no-v-html](./no-v-html.html) | disallow use of localization methods on v-html to prevent XSS attack | :star: |
+| [@intlify/vue-i18n/<wbr>valid-message-syntax](./valid-message-syntax.html) | disallow invalid message syntax |  |
 
 ## Best Practices
 
-| Rule ID                                                                                            | Description                                                 |             |
-| :------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :---------- |
-| [@intlify/vue-i18n/<wbr>key-format-style](./key-format-style.html)                                 | enforce specific casing for localization keys               |             |
-| [@intlify/vue-i18n/<wbr>no-duplicate-keys-in-locale](./no-duplicate-keys-in-locale.html)           | disallow duplicate localization keys within the same locale |             |
-| [@intlify/vue-i18n/<wbr>no-dynamic-keys](./no-dynamic-keys.html)                                   | disallow localization dynamic keys at localization methods  |             |
-| [@intlify/vue-i18n/<wbr>no-missing-keys-in-other-locales](./no-missing-keys-in-other-locales.html) | disallow missing locale message keys in other locales       |             |
-| [@intlify/vue-i18n/<wbr>no-unused-keys](./no-unused-keys.html)                                     | disallow unused localization keys                           | :black_nib: |
+<!--prettier-ignore-->
+| Rule ID | Description |    |
+|:--------|:------------|:---|
+| [@intlify/vue-i18n/<wbr>key-format-style](./key-format-style.html) | enforce specific casing for localization keys |  |
+| [@intlify/vue-i18n/<wbr>no-duplicate-keys-in-locale](./no-duplicate-keys-in-locale.html) | disallow duplicate localization keys within the same locale |  |
+| [@intlify/vue-i18n/<wbr>no-dynamic-keys](./no-dynamic-keys.html) | disallow localization dynamic keys at localization methods |  |
+| [@intlify/vue-i18n/<wbr>no-missing-keys-in-other-locales](./no-missing-keys-in-other-locales.html) | disallow missing locale message keys in other locales |  |
+| [@intlify/vue-i18n/<wbr>no-unused-keys](./no-unused-keys.html) | disallow unused localization keys | :black_nib: |
 
 ## Stylistic Issues
 
-| Rule ID                                                                                    | Description                                      |             |
-| :----------------------------------------------------------------------------------------- | :----------------------------------------------- | :---------- |
+<!--prettier-ignore-->
+| Rule ID | Description |    |
+|:--------|:------------|:---|
 | [@intlify/vue-i18n/<wbr>prefer-linked-key-with-paren](./prefer-linked-key-with-paren.html) | enforce linked key to be enclosed in parentheses | :black_nib: |

--- a/docs/rules/no-deprecated-i18n-component.md
+++ b/docs/rules/no-deprecated-i18n-component.md
@@ -5,7 +5,9 @@ description: disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)
 
 # @intlify/vue-i18n/no-deprecated-i18n-component
 
-> disallow duplicate localization keys within the same locale
+> disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)
+
+- :black_nib:️ The `--fix` option on the [command line](http://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
 
 If you are migrating from Vue I18n v8 to v9, the `<i18n>` component should be replaced with the `<i18n-t>` component.
 

--- a/docs/rules/no-deprecated-i18n-component.md
+++ b/docs/rules/no-deprecated-i18n-component.md
@@ -1,0 +1,63 @@
+---
+title: '@intlify/vue-i18n/no-deprecated-i18n-component'
+description: disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)
+---
+
+# @intlify/vue-i18n/no-deprecated-i18n-component
+
+> disallow duplicate localization keys within the same locale
+
+If you are migrating from Vue I18n v8 to v9, the `<i18n>` component should be replaced with the `<i18n-t>` component.
+
+## :book: Rule Details
+
+This rule reports use of deprecated `<i18n>` components (in Vue I18n 9.0.0+).
+
+:-1: Examples of **incorrect** code for this rule:
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```vue
+<script>
+/* eslint @intlify/vue-i18n/no-deprecated-i18n-component: 'error' */
+</script>
+<template>
+  <div class="app">
+    <!-- ✗ BAD -->
+    <i18n path="message.greeting" />
+  </div>
+</template>
+```
+
+</eslint-code-block>
+
+:+1: Examples of **correct** code for this rule:
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```vue
+<script>
+/* eslint @intlify/vue-i18n/no-deprecated-i18n-component: 'error' */
+</script>
+<template>
+  <div class="app">
+    <!-- ✓ GOOD -->
+    <i18n-t keypath="message.greeting" />
+  </div>
+</template>
+```
+
+</eslint-code-block>
+
+## :books: Further reading
+
+- [Vue I18n > Breaking Changes - Rename to `i18n-t` from `i18n`](https://vue-i18n.intlify.dev/guide/migration/breaking.html#rename-to-i18n-tfrom-i18n)
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/intlify/eslint-plugin-vue-i18n/blob/master/lib/rules/no-deprecated-i18n-component.ts)
+- [Test source](https://github.com/intlify/eslint-plugin-vue-i18n/tree/master/tests/lib/rules/no-deprecated-i18n-component.ts)

--- a/lib/rules.ts
+++ b/lib/rules.ts
@@ -1,5 +1,6 @@
 /** DON'T EDIT THIS FILE; was created by scripts. */
 import keyFormatStyle from './rules/key-format-style'
+import noDeprecatedI18nComponent from './rules/no-deprecated-i18n-component'
 import noDuplicateKeysInLocale from './rules/no-duplicate-keys-in-locale'
 import noDynamicKeys from './rules/no-dynamic-keys'
 import noHtmlMessages from './rules/no-html-messages'
@@ -13,6 +14,7 @@ import validMessageSyntax from './rules/valid-message-syntax'
 
 export = {
   'key-format-style': keyFormatStyle,
+  'no-deprecated-i18n-component': noDeprecatedI18nComponent,
   'no-duplicate-keys-in-locale': noDuplicateKeysInLocale,
   'no-dynamic-keys': noDynamicKeys,
   'no-html-messages': noHtmlMessages,

--- a/lib/rules/no-deprecated-i18n-component.ts
+++ b/lib/rules/no-deprecated-i18n-component.ts
@@ -1,0 +1,101 @@
+/**
+ * @author Yosuke Ota
+ */
+import { defineTemplateBodyVisitor } from '../utils/index'
+import type { RuleContext, RuleListener } from '../types'
+import type { AST as VAST } from 'vue-eslint-parser'
+
+function create(context: RuleContext): RuleListener {
+  return defineTemplateBodyVisitor(context, {
+    VElement(node: VAST.VElement) {
+      if (node.name !== 'i18n') {
+        return
+      }
+      const tokenStore = context.parserServices.getTemplateBodyTokenStore()
+      const tagNameToken = tokenStore.getFirstToken(node.startTag)
+      context.report({
+        node: tagNameToken,
+        messageId: 'deprecated',
+        *fix(fixer) {
+          yield fixer.replaceText(tagNameToken, '<i18n-t')
+
+          let hasTag = false
+          for (const attr of node.startTag.attributes) {
+            if (attr.directive) {
+              if (attr.key.name.name !== 'bind') {
+                continue
+              }
+              if (
+                !attr.key.argument ||
+                attr.key.argument.type !== 'VIdentifier'
+              ) {
+                continue
+              }
+              if (attr.key.argument.name === 'path') {
+                yield fixer.replaceText(attr.key.argument, 'keypath')
+              } else if (attr.key.argument.name === 'tag') {
+                hasTag = true
+                if (
+                  attr.value &&
+                  attr.value.expression &&
+                  attr.value.expression.type === 'Literal' &&
+                  typeof attr.value.expression.value === 'boolean'
+                ) {
+                  if (attr.value.expression.value) {
+                    // :tag="true"
+                    yield fixer.replaceText(attr, 'tag="span"')
+                  } else {
+                    yield fixer.remove(attr)
+                  }
+                }
+              }
+            } else {
+              if (attr.key.name === 'path') {
+                yield fixer.replaceText(attr.key, 'keypath')
+              } else if (attr.key.name === 'tag') {
+                hasTag = true
+              }
+            }
+          }
+          if (!hasTag) {
+            // Add a default `tag` for the <i18n> component.
+            yield fixer.insertTextAfter(
+              (node.startTag.attributes.length > 0 &&
+                node.startTag.attributes[
+                  node.startTag.attributes.length - 1
+                ]) ||
+                tagNameToken,
+              ' tag="span"'
+            )
+          }
+
+          if (node.endTag) {
+            yield fixer.replaceText(
+              tokenStore.getFirstToken(node.endTag),
+              '</i18n-t'
+            )
+          }
+        }
+      })
+    }
+  })
+}
+
+export = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow using deprecated `<i18n>` components (in Vue I18n 9.0.0+)',
+      category: 'Recommended',
+      recommended: false
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      deprecated:
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+    }
+  },
+  create
+}

--- a/scripts/update-docs-index.ts
+++ b/scripts/update-docs-index.ts
@@ -26,6 +26,7 @@ function toCategorySection({
 }) {
   return `## ${category}
 
+<!--prettier-ignore-->
 | Rule ID | Description |    |
 |:--------|:------------|:---|
 ${rules.map(toTableRow).join('\n')}

--- a/scripts/update-rule-docs.ts
+++ b/scripts/update-rule-docs.ts
@@ -7,7 +7,7 @@ import { writeFileSync, readFileSync } from 'fs'
 import { join } from 'path'
 import type { RuleInfo } from './lib/rules'
 import rules from './lib/rules'
-const PLACE_HOLDER = /^#[^\n]*\n+> .+\n+(?:- .+\n)*\n*/u
+const PLACE_HOLDER = /#[^\n]*\n+> .+\n+(?:- .+\n)*\n*/u
 
 export function updateRuleDocs({
   nextVersion

--- a/tests/lib/rules/no-deprecated-i18n-component.ts
+++ b/tests/lib/rules/no-deprecated-i18n-component.ts
@@ -1,0 +1,249 @@
+/**
+ * @author Yosuke Ota
+ */
+import { RuleTester } from 'eslint'
+import rule = require('../../../lib/rules/no-deprecated-i18n-component')
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: { ecmaVersion: 2015 }
+})
+
+tester.run('no-deprecated-i18n-component', rule as never, {
+  valid: [
+    {
+      code: `
+      <template>
+        <i18n-t keypath="message.greeting" />
+      </template>
+      `
+    },
+    {
+      code: `
+      <template>
+        <i18n-t keypath="info" tag="p">
+          <template #limit>
+            <span>{{ refundLimit }}</span>
+          <template>
+          <template #action>
+            <a :href="refundUrl">{{ $t('refund') }}</a>
+          <template>
+        </i18n-t>
+      </template>
+      `
+    },
+    {
+      code: `
+      <i18n>{}<i18n>
+      <template>
+      </template>
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+      <template>
+        <i18n path="message.greeting" />
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t keypath="message.greeting" tag="span" />
+      </template>
+      `,
+      errors: [
+        {
+          message:
+            'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.',
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n path="message.greeting" tag="div" />
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t keypath="message.greeting" tag="div" />
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n :tag="false" path="message.greeting">
+          <span>hello!</span>
+        </i18n>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t  keypath="message.greeting">
+          <span>hello!</span>
+        </i18n-t>
+      </template>
+      `,
+      errors: [
+        {
+          message:
+            'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.',
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n path="message.greeting" :tag="false" >
+          <span>hello!</span>
+        </i18n>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t keypath="message.greeting"  >
+          <span>hello!</span>
+        </i18n-t>
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n path="message.greeting">
+          <span>hello!</span>
+        </i18n>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t keypath="message.greeting" tag="span">
+          <span>hello!</span>
+        </i18n-t>
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n tag="div" path="message.greeting">
+          <span>hello!</span>
+        </i18n>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t tag="div" keypath="message.greeting">
+          <span>hello!</span>
+        </i18n-t>
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n/>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t tag="span"/>
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n :path="messageKey" />
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t :keypath="messageKey" tag="span" />
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n v-bind:path="messageKey" />
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t v-bind:keypath="messageKey" tag="span" />
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n
+          v-if="shown"
+          v-on:path="handle"
+          v-bind:foo="fakeMessageKey"
+          v-bind:[path]="fakeMessageKey"
+          v-bind:path="messageKey"
+        />
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t
+          v-if="shown"
+          v-on:path="handle"
+          v-bind:foo="fakeMessageKey"
+          v-bind:[path]="fakeMessageKey"
+          v-bind:keypath="messageKey" tag="span"
+        />
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    },
+    {
+      code: `
+      <template>
+        <i18n :tag="true"/>
+      </template>
+      `,
+      output: `
+      <template>
+        <i18n-t tag="span"/>
+      </template>
+      `,
+      errors: [
+        'Deprecated <i18n> component was found. For VueI18n v9.0, use <i18n-t> component instead.'
+      ]
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds `@intlify/vue-i18n/no-deprecated-i18n-component` rule that reports use of deprecated `<i18n>` components (in Vue I18n 9.0.0+).

refs #161 

In #161, the name of the rule was proposed as `no-deprecated-translation-component-name`, but if `<i18n-t>` is deprecated in v10+, it will be difficult to think of a rule with a new name, so the rule I renamed it to `no-deprecated-i18n-component`.

