### PR TITLE
fix: add debug as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@intlify/message-compiler": "^9.0.0-rc.5",
     "@intlify/message-resolver": "^9.0.0-rc.5",
+    "debug": "^4.3.1",
     "glob": "^7.1.3",
     "ignore": "^5.0.5",
     "js-yaml": "^4.0.0",


### PR DESCRIPTION
And another fix for usage with yarn 2 :see_no_evil: 

```
Error: Failed to load plugin '@intlify/vue-i18n' declared in '.eslintrc.js': @intlify/eslint-plugin-vue-i18n tried to access debug, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: debug (via "debug")
Required by: @intlify/eslint-plugin-vue-i18n@virtual:4ad93fa146a4e0d5ddd4599ecd9d82ecb03b424b9240d3d1508d839a1bff9fac247ecac5d150c68fb68844d9d337327ae2ac370f3cd8a72ffa073d59a537b0db#npm:0.11.0 (via ./.yarn/$$virtual/@intlify-eslint-plugin-vue-i18n-virtual-940b1fb35b/0/cache/@intlify-eslint-plugin-vue-i18n-npm-0.11.0-b29cdc793c-290af4444f.zip/node_modules/@intlify/eslint-plugin-vue-i18n/dist/rules/)
```