### PR TITLE
Make to support i18n key that has `.`(dots)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,6 @@ Go to [Get Started](./started.md)
   </a>
 </p>
 
-
 ## Become a Sponsor
 
 Is your company using eslint-plugin-vue-i18n, and related [Intlify](https://github.com/intlify) project i18n tools to build awesome apps? Become a sponsor to add your logo on this documentation! Supporting me on GitHub Sponsors and Patreon allows me to work less for a job and to work more on Free Open Source Software such as eslint-plugin-vue-i18n! Thank you!

--- a/lib/utils/locale-messages.ts
+++ b/lib/utils/locale-messages.ts
@@ -261,6 +261,15 @@ export class LocaleMessages {
       let i = 0
       let missing = false
       while (i < length) {
+        const remainedKey = paths.slice(i).join('.')
+        if (
+          lasts.some(
+            last => last && typeof last !== 'string' && last[remainedKey]
+          )
+        ) {
+          break
+        }
+
         const values: I18nLocaleMessageValue[] = lasts
           .map(last => {
             return last && typeof last !== 'string' ? last[paths[i]] : undefined

--- a/tests/fixtures/no-missing-keys/constructor-option-format/locales/index.json
+++ b/tests/fixtures/no-missing-keys/constructor-option-format/locales/index.json
@@ -7,8 +7,10 @@
       "nested": {
         "hello": "hi jojo!"
       },
+      "not_nested.world": "hi world!",
       "en-only": "en-only"
     },
+    "messages.not_nested.hello": "hi hello!",
     "hello_dio": "hello underscore DIO!",
     "hello {name}": "hello {name}!",
     "hello-dio": "hello hyphen DIO!"
@@ -20,8 +22,10 @@
       "link": "@:message.hello",
       "nested": {
         "hello": "こんにちは、ジョジョ!"
-      }
+      },
+      "not_nested.world": "こんにちは、 world!"
     },
+    "messages.not_nested.hello": "こんにちは、 hello!",
     "hello_dio": "こんにちは、アンダースコア DIO！",
     "hello {name}": "こんにちは、{name}！",
     "hello-dio": "こんにちは、ハイフン DIO！"

--- a/tests/fixtures/no-missing-keys/multiple-locales/locales1/en.json
+++ b/tests/fixtures/no-missing-keys/multiple-locales/locales1/en.json
@@ -6,6 +6,7 @@
     "nested": {
       "hello": "hi jojo!"
     },
+    "not_nested.world": "hi world!",
     "en-only": "en-only"
   }
 }

--- a/tests/fixtures/no-missing-keys/multiple-locales/locales2/index.json
+++ b/tests/fixtures/no-missing-keys/multiple-locales/locales2/index.json
@@ -6,8 +6,10 @@
       "link": "@:message.hello",
       "nested": {
         "hello": "こんにちは、ジョジョ!"
-      }
+      },
+      "not_nested.world": "こんにちは、 world!"
     },
+    "messages.not_nested.hello": "こんにちは、 hello!",
     "hello_dio": "こんにちは、アンダースコア DIO！",
     "hello {name}": "こんにちは、{name}！",
     "hello-dio": "こんにちは、ハイフン DIO！"

--- a/tests/fixtures/no-missing-keys/multiple-locales/locales3/en.json
+++ b/tests/fixtures/no-missing-keys/multiple-locales/locales3/en.json
@@ -1,4 +1,5 @@
 {
+  "messages.not_nested.hello": "hi hello!",
   "hello_dio": "hello underscore DIO!",
   "hello {name}": "hello {name}!",
   "hello-dio": "hello hyphen DIO!"

--- a/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.2.json
+++ b/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.2.json
@@ -1,4 +1,5 @@
 {
+  "messages.not_nested.hello": "hi hello!",
   "hello_dio": "hello underscore DIO!",
   "hello {name}": "hello {name}!",
   "hello-dio": "hello hyphen DIO!"

--- a/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.json
+++ b/tests/fixtures/no-missing-keys/vue-cli-format/locales/en.json
@@ -6,6 +6,7 @@
     "nested": {
       "hello": "hi jojo!"
     },
+    "not_nested.world": "hi world!",
     "en-only": "en-only"
   }
 }

--- a/tests/lib/rules/no-missing-keys.ts
+++ b/tests/lib/rules/no-missing-keys.ts
@@ -57,6 +57,14 @@ tester.run('no-missing-keys', rule as never, {
         code: `$t('hello')`
       },
       {
+        // not nested key
+        code: `t('messages.not_nested.hello')`
+      },
+      {
+        // partial nested key
+        code: `t('messages.not_nested.world')`
+      },
+      {
         // nested key
         code: `t('messages.nested.hello')`
       },


### PR DESCRIPTION
I made that it can be used even when I have i18n data like the following

```json
{
  "hello": "hello world",
  "messages": {
    "hello": "hi DIO!",
    "link": "@:message.hello",
    "nested": {
      "hello": "hi jojo!"
    },
    "not_nested.world": "hi world!",
    "en-only": "en-only"
  }
}
```

```js
$t("hello.messages.not_nested.hello");
$t("hello.messages.not_nested.world");
```