### PR TITLE
Fix false negatives for `<i18n-t keypath>` in `no-missing-key` rule

### DIFF
--- a/lib/rules/no-missing-keys.ts
+++ b/lib/rules/no-missing-keys.ts
@@ -17,13 +17,8 @@ function create(context: RuleContext): RuleListener {
         checkDirective(context, node)
       },
 
-      "VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[key.name='path']"(
-        node: VAST.VAttribute
-      ) {
-        checkComponent(context, node)
-      },
-
-      "VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[key.name.name='path']"(
+      ["VElement:matches([name=i18n], [name=i18n-t]) > VStartTag > VAttribute[key.name='path']," +
+      "VElement[name=i18n-t] > VStartTag > VAttribute[key.name='keypath']"](
         node: VAST.VAttribute
       ) {
         checkComponent(context, node)

--- a/tests/lib/rules/no-missing-keys.ts
+++ b/tests/lib/rules/no-missing-keys.ts
@@ -161,6 +161,14 @@ tester.run('no-missing-keys', rule as never, {
     <template>
       <div id="app"></div>
     </template>`
+      },
+      {
+        filename: 'test.vue',
+        code: `
+        <i18n locale="en">{"hello": "hello"}</i18n>
+        <template>
+          <i18n-t keypath="'hello'"></i18n-t>
+        </template>`
       }
     ]
   ),
@@ -278,6 +286,15 @@ tester.run('no-missing-keys', rule as never, {
       <p v-t="'missing'"></p>
     </template>`,
         errors: [`'missing' does not exist in localization message resources`]
+      },
+      {
+        filename: 'test.vue',
+        code: `
+        <i18n locale="en">{"hello": "hello"}</i18n>
+        <template>
+          <i18n-t keypath="hi"></i18n-t>
+        </template>`,
+        errors: [`'hi' does not exist in localization message resources`]
       }
     ]
   )


### PR DESCRIPTION
refs #251 

---

This will increase the warning and should be released in a minor version.