### PR TITLE
Fix false negatives when using parsers other than vue-eslint-parser in no-missing-keys

### DIFF
--- a/lib/rules/no-missing-keys.ts
+++ b/lib/rules/no-missing-keys.ts
@@ -5,16 +5,16 @@ import {
   defineTemplateBodyVisitor,
   getLocaleMessages,
   getStaticLiteralValue,
-  isStaticLiteral
+  isStaticLiteral,
+  compositingVisitors
 } from '../utils/index'
 import type { AST as VAST } from 'vue-eslint-parser'
 import type { RuleContext, RuleListener } from '../types'
 import { createRule } from '../utils/rule'
 
 function create(context: RuleContext): RuleListener {
-  return defineTemplateBodyVisitor(
-    context,
-    {
+  return compositingVisitors(
+    defineTemplateBodyVisitor(context, {
       "VAttribute[directive=true][key.name='t']"(node: VAST.VDirective) {
         checkDirective(context, node)
       },
@@ -33,7 +33,7 @@ function create(context: RuleContext): RuleListener {
       CallExpression(node: VAST.ESLintCallExpression) {
         checkCallExpression(context, node)
       }
-    },
+    }),
     {
       CallExpression(node: VAST.ESLintCallExpression) {
         checkCallExpression(context, node)

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -535,7 +535,7 @@ export function skipTSAsExpression<T extends VAST.Node>(node: T): T {
   return node
 }
 
-function compositingVisitors(
+export function compositingVisitors(
   visitor: RuleListener,
   ...visitors: RuleListener[]
 ) {

--- a/tests/lib/rules/no-missing-keys.ts
+++ b/tests/lib/rules/no-missing-keys.ts
@@ -218,7 +218,7 @@ tester.run('no-missing-keys', rule as never, {
     ]
   ),
 
-  invalid: buildTestsForLocales(
+  invalid: buildTestsForLocales<RuleTester.InvalidTestCase>(
     [
       {
         // basic
@@ -271,6 +271,13 @@ tester.run('no-missing-keys', rule as never, {
       },
       {
         // nested missing
+        code: `$t('messages.missing')`,
+        errors: [
+          `'messages.missing' does not exist in localization message resources`
+        ]
+      },
+      {
+        parser: require.resolve('espree'),
         code: `$t('messages.missing')`,
         errors: [
           `'messages.missing' does not exist in localization message resources`


### PR DESCRIPTION


fixes #310