### PR TITLE
Add support for includeFilenameInKey to address issue #336

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -64,6 +64,13 @@ module.export = {
       //     pattern: './path/to/locales3/*.{json,json5,yaml,yml}',
       //     localeKey: 'key'
       //   },
+      //   {
+      //     // 'path' case - including filenames in the key
+      //     pattern: './path/to/locales4/*.{json,json5,yaml,yml}',
+      //     localePattern: /^.*\/(?<locale>[A-Za-z0-9-_]+)\/.*\.(json5?|ya?ml)$/,
+      //     localeKey: 'path',
+      //     includeFilenameInKey: true
+      //   },
       // ]
 
       // Specify the version of `vue-i18n` you are using.
@@ -87,6 +94,7 @@ See [the rule list](../rules/)
       - `'path'` ... Determine the locale name from the path. In this case, the locale must be had structured with your rule on the path. It can be captured with the regular expression named capture. The resource file should only contain messages for that locale.
       - `'key'` ... Determine the locale name from the root key name of the file contents. The value of that key should only contain messages for that locale. Used when the resource file is in the format given to the `messages` option of the `VueI18n` constructor option.
     - `localePattern` ... Specifies how to determine pattern the locale for localization messages. This option means, when `localeKey` is `'path'`, you will need to capture the locale using a regular expression. You need to use the locale capture as a named capture `?<locale>`, so it’s be able to capture from the path of the locale resources. If you omit it, it will be captured from the resource path with the same regular expression pattern as `vue-cli-plugin-i18n`.
+    - `includeFilenameInKey` ... Specifies if the filename (without the extension) should be considered as part of the message keys. This is only valid when localeKey is set to 'path'. For example, the key 'title' in the file 'common.json' would be considered to have key 'common.title' if this flag is set to true.
   - Array option ... An array of String option and Object option. Useful if you have multiple locale directories.
 - `messageSyntaxVersion` (Optional) ... Specify the version of `vue-i18n` you are using. If not specified, the message will be parsed twice. Also, some rules require this setting.
 

--- a/lib/types/settings.ts
+++ b/lib/types/settings.ts
@@ -39,4 +39,11 @@ export interface SettingsVueI18nLocaleDirObject {
    * If you omit it, it will be captured from the resource path with the same regular expression pattern as `vue-cli-plugin-i18n`.
    */
   localePattern?: string | RegExp
+  /**
+   * Specifies if the filename (without the extension) should be considered as part of the message keys.
+   *
+   * This is only valid when localeKey is set to 'path'.
+   * For example, the key 'title' in the file 'common.json' would be considered to have key 'common.title'.
+   */
+  includeFilenameInKey?: boolean
 }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -30,6 +30,7 @@ interface LocaleFiles {
   files: string[]
   localeKey: LocaleKeyType
   localePattern?: string | RegExp
+  includeFilenameInKey?: boolean
 }
 const UNEXPECTED_ERROR_LOCATION = { line: 1, column: 0 }
 /**
@@ -129,7 +130,12 @@ function loadLocaleMessages(
 ): FileLocaleMessage[] {
   const results: FileLocaleMessage[] = []
   const checkDupeMap: { [file: string]: LocaleKeyType[] } = {}
-  for (const { files, localeKey, localePattern } of localeFilesList) {
+  for (const {
+    files,
+    localeKey,
+    localePattern,
+    includeFilenameInKey
+  } of localeFilesList) {
     for (const file of files) {
       const localeKeys = checkDupeMap[file] || (checkDupeMap[file] = [])
       if (localeKeys.includes(localeKey)) {
@@ -138,7 +144,12 @@ function loadLocaleMessages(
       localeKeys.push(localeKey)
       const fullpath = resolve(cwd, file)
       results.push(
-        new FileLocaleMessage({ fullpath, localeKey, localePattern })
+        new FileLocaleMessage({
+          fullpath,
+          localeKey,
+          localePattern,
+          includeFilenameInKey
+        })
       )
     }
   }
@@ -245,7 +256,8 @@ class LocaleDirLocaleMessagesCache {
       return {
         files: targetFilesLoader.get(localeDir.pattern, cwd),
         localeKey: String(localeDir.localeKey ?? 'file') as LocaleKeyType,
-        localePattern: localeDir.localePattern
+        localePattern: localeDir.localePattern,
+        includeFilenameInKey: localeDir.includeFilenameInKey
       }
     }
   }

--- a/lib/utils/path-utils.ts
+++ b/lib/utils/path-utils.ts
@@ -31,3 +31,11 @@ export function getRelativePath(filepath: string, baseDir: string): string {
   }
   return absolutePath.replace(/^\//, '')
 }
+
+export function getBasename(filepath: string): string {
+  return filepath
+    .replace(/^.*(\\|\/|:)/, '')
+    .split('.')
+    .slice(0, -1)
+    .join('.')
+}

--- a/tests/lib/utils/locale-messages.ts
+++ b/tests/lib/utils/locale-messages.ts
@@ -48,4 +48,23 @@ describe('FileLocaleMessage', () => {
       assert.deepStrictEqual(messages.locales, ['en', 'ja'])
     })
   })
+
+  describe('localeKey: "path" with includeFilenameInKey = true', () => {
+    it('messages returned should be keyed by the filename', () => {
+      const testFilePath = path.resolve(
+        __dirname,
+        '../../fixtures/utils/locale-messages/locales/en/message.json'
+      )
+      const messages = new FileLocaleMessage({
+        fullpath: testFilePath,
+        localeKey: 'path',
+        localePattern: /^.*\/(?<locale>[A-Za-z0-9-_]+)\/.*\.(json5?|ya?ml)$/,
+        includeFilenameInKey: true
+      })
+      assert.deepStrictEqual(Object.keys(messages.messages), ['message'])
+      assert.deepStrictEqual(Object.keys(messages.messages['message'] || {}), [
+        'hello'
+      ])
+    })
+  })
 })

--- a/tests/lib/utils/path-utils.ts
+++ b/tests/lib/utils/path-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * @author Yosuke Ota
+ */
+import assert from 'assert'
+import { getBasename } from '../../../lib/utils/path-utils'
+
+describe('getBasename', () => {
+  it('return the filename without the extension', () => {
+    assert.strictEqual(
+      getBasename('~/some/clever/path/to/common.json'),
+      'common'
+    )
+
+    assert.strictEqual(
+      getBasename('~/some/clever/path/to/dotted.file.json'),
+      'dotted.file'
+    )
+  })
+})


### PR DESCRIPTION
This PR addresses the issue raised here - https://github.com/intlify/eslint-plugin-vue-i18n/issues/336 by adding support for the `includeFilenameInKey` field in .eslintrc.js settings.

This flag specifies if the filename (without the extension) should be considered as part of the message keys. This is only valid when localeKey is set to 'path'. For example, the key 'title' in the file 'common.json' would be considered to have key 'common.title' if this flag is set to true.

The only rule that this affected seemed to be `no-duplicate-keys-in-locale` - which I've addressed in this PR.

Documentation and tests have been added. 

If we can get this into a release soon that would be amazing for us as we use your eslint plugin extensively! Thanks so much for your work on this project & it was pretty easy to work on.