### PR TITLE
fix: no-missing-keys rule reports false positive with trailing dot

### DIFF
--- a/.changeset/forty-tools-dream.md
+++ b/.changeset/forty-tools-dream.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": patch
+---
+
+fix: no-missing-keys rule reports false positive with trailing dot

--- a/lib/utils/key-path.ts
+++ b/lib/utils/key-path.ts
@@ -21,5 +21,5 @@ export function joinPath(...paths: (string | number)[]): string {
 }
 
 export function parsePath(path: string): string[] {
-  return parse(path) || []
+  return parse(path) || [path]
 }

--- a/tests/lib/rules/no-missing-keys.ts
+++ b/tests/lib/rules/no-missing-keys.ts
@@ -167,7 +167,7 @@ tester.run('no-missing-keys', rule as never, {
         code: `
         <i18n locale="en">{"hello": "hello"}</i18n>
         <template>
-          <i18n-t keypath="'hello'"></i18n-t>
+          <i18n-t keypath="hello"></i18n-t>
         </template>`
       },
       {
@@ -270,6 +270,13 @@ tester.run('no-missing-keys', rule as never, {
       </div>
     </template>`,
         errors: [`'missing' does not exist in localization message resources`]
+      },
+      {
+        // missing ending with a dot
+        code: `$t('missing.')`,
+        errors: [
+          `'["missing."]' does not exist in localization message resources`
+        ]
       },
       {
         // nested basic


### PR DESCRIPTION
(as noted in https://github.com/intlify/eslint-plugin-vue-i18n/issues/260#issuecomment-1618963764)

For a translation key like `$t('missing.')` the parse function from core utilities returns undefined.

Previously this was turned into an empty array which caused all of those paths to be false positives.

If the given key can't be parsed as "path" properly, the correct handling is to treat it as a single item path with the provided string as the only item.

This also revealed another faulty test, where `keypath="'hello'"` was passing even though it should not.