### PR TITLE
chore(changeset): set base branch to `master`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   ],
   "commit": false,
   "linked": [],
-  "baseBranch": "main",
+  "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []

--- a/.changeset/smart-bugs-study.md
+++ b/.changeset/smart-bugs-study.md
@@ -1,5 +1,0 @@
----
-'@intlify/eslint-plugin-vue-i18n': patch
----
-
-Set base branch to `master`.

--- a/.changeset/smart-bugs-study.md
+++ b/.changeset/smart-bugs-study.md
@@ -1,0 +1,5 @@
+---
+'@intlify/eslint-plugin-vue-i18n': patch
+---
+
+Set base branch to `master`.


### PR DESCRIPTION
The repository does not have a `main` branch as of now.

Alternatively, the repository's main branch can be renamed of course.