### PR TITLE
docs: enable local search

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,6 +18,9 @@ export default async () => {
           'https://github.com/intlify/eslint-plugin-vue-i18n/edit/master/docs/:path',
         text: 'Edit this page on GitHub'
       },
+      search: {
+        provider: 'local'
+      },
       nav: [
         {
           text: 'Support Intlify',


### PR DESCRIPTION
I was trying to look something up in the docs and noticed that local search was not enabled in VitePress. It looks like this:

![grafik](https://github.com/intlify/eslint-plugin-vue-i18n/assets/13335308/c99b6acc-fe08-48a1-9985-b1b73d8e384e)

---

Note: [CONTRIBUTING.md](https://github.com/intlify/eslint-plugin-vue-i18n/blob/281a248f4800e8f8ba84da80c7fded592e379104/.github/CONTRIBUTING.md#pull-request-guidelines) suggests submitting PRs to `dev`, but that branch does not seem to exist.