### PR TITLE
fix: Bump tsconfig target to es2017 to avoid polyfilling await

### DIFF
--- a/.changeset/rotten-kangaroos-hope.md
+++ b/.changeset/rotten-kangaroos-hope.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": minor
+---
+
+fix: Bump tsconfig target to es2017 to avoid polyfilling await

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "node16" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true /* Allow javascript files to be compiled. */,


### PR DESCRIPTION
Currently the `target` in the `tsconfig.json` file it set to ES2015, which means that the TypeScript compiler is polyfilling the `await` keyword in `lib/utils/parser-config-resolver/worker.ts` because it is an ES2017 language feature.

To avoid that happening this pull request bumps the target in the `tsconfig.json` file to ES2017. This is a non-breaking change as this package dropped Node.js versions older than 18 in version 3.0.0 and Node.js 18 supports ES2022 language features.

Before and after diff of `dist/utils/parser-config-resolver/worker.js`:

```diff
@@ -1,21 +1,12 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const synckit_1 = require("synckit");
 const eslint_1 = require("eslint-compat-utils/eslint");
 const parse_by_parser_1 = require("./parse-by-parser");
 const ESLint = (0, eslint_1.getESLint)();
-(0, synckit_1.runAsWorker)((cwd, filePath) => __awaiter(void 0, void 0, void 0, function* () {
+(0, synckit_1.runAsWorker)(async (cwd, filePath) => {
     const eslint = new ESLint({ cwd });
-    const config = yield eslint.calculateConfigForFile(filePath);
+    const config = await eslint.calculateConfigForFile(filePath);
     const languageOptions = config.languageOptions || {};
     const parserOptions = Object.assign({
         sourceType: languageOptions.sourceType || 'module',
@@ -38,4 +29,4 @@ const ESLint = (0, eslint_1.getESLint)();
         ast: result.ast,
         visitorKeys: result === null || result === void 0 ? void 0 : result.visitorKeys
     };
-}));
+});
```