### PR TITLE
feat!: rename configs

### DIFF
--- a/.changeset/seven-boxes-call.md
+++ b/.changeset/seven-boxes-call.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": major
+---
+
+feat!: rename configs

--- a/docs/started.md
+++ b/docs/started.md
@@ -29,9 +29,9 @@ import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 export default [
   // add more generic rulesets here, such as:
   // js.configs.recommended, // '@eslint/js'
-  // ...vue.configs['flat/recommended'], // 'eslint-plugin-vue'
+  // ...vue.configs.['flat/recommended'], // 'eslint-plugin-vue'
 
-  ...vueI18n.configs['flat/recommended'],
+  ...vueI18n.configs.recommended,
   {
     rules: {
       // Optional.
@@ -86,8 +86,8 @@ See the [rule list](./rules/index.md) to get the `configs` & `rules` that this p
 
 This plugin provides some predefined configs. You can use the following configs by adding them to `eslint.config.[c|m]js`. (All flat configs in this plugin are provided as arrays, so spread syntax is required when combining them with other configs.)
 
-- `*.configs["flat/base"]`: Settings and rules to enable correct ESLint parsing.
-- `*.configs["flat/recommended"]`: Above, plus rules to enforce subjective community defaults to ensure consistency.
+- `*.configs.base`: Settings and rules to enable correct ESLint parsing.
+- `*.configs.recommended`: Above, plus rules to enforce subjective community defaults to ensure consistency.
 
 ### Configuration `.eslintrc.*`
 
@@ -102,7 +102,7 @@ module.export = {
   extends: [
     'eslint:recommended',
     // Recommended
-    'plugin:@intlify/vue-i18n/recommended'
+    'plugin:@intlify/vue-i18n/recommended-legacy'
   ],
   rules: {
     // Optional.
@@ -156,8 +156,8 @@ See the [rule list](./rules/index.md) to get the `configs` & `rules` that this p
 
 This plugin provides some predefined configs. You can use the following configs by adding them to `.eslintrc.*`.
 
-- `"plugin:@intlify/vue-i18n/base"`: Settings and rules to enable correct ESLint parsing.
-- `"plugin:@intlify/vue-i18n/recommended"`: Above, plus rules to enforce subjective community defaults to ensure consistency.
+- `"plugin:@intlify/vue-i18n/base-legacy"`: Settings and rules to enable correct ESLint parsing.
+- `"plugin:@intlify/vue-i18n/recommended-legacy"`: Above, plus rules to enforce subjective community defaults to ensure consistency.
 
 ### `settings['vue-i18n']`
 
@@ -201,24 +201,21 @@ eslint "src/**/*.{js,vue,json}"
 
 If you want to use custom parsers such as [babel-eslint](https://www.npmjs.com/package/babel-eslint) or [typescript-eslint-parser](https://www.npmjs.com/package/typescript-eslint-parser), you have to use `parserOptions.parser` option instead of `parser` option. Because this plugin requires [vue-eslint-parser](https://www.npmjs.com/package/vue-eslint-parser) to parse `.vue` files, so this plugin doesn't work if you overwrote `parser` option.
 
-Also, `parserOptions` configured at the top level affect `.json` and `.yaml`. This plugin needs to use special parsers to parse `.json` and `.yaml`, so to correctly parse each extension, use the `overrides` option and overwrite the options again.
-
 ```diff
-- "parser": "babel-eslint",
-  "parserOptions": {
-+     "parser": "babel-eslint",
+import vueEslintParser from "vue-eslint-parser"
+import babelEslint from "babel-eslint"
+
+export default {
+  "files": ["**/*.vue"],
+  "languageOptions": {
+-   "parser": babelEslint,
++   "parser": vueEslintParser,
+    "parserOptions": {
++     "parser": babelEslint,
       "sourceType": "module"
-  },
-+ "overrides": [
-+     {
-+         "files": ["*.json", "*.json5"],
-+         "extends": ["plugin:@intlify/vue-i18n/base"],
-+     },
-+     {
-+         "files": ["*.yaml", "*.yml"],
-+         "extends": ["plugin:@intlify/vue-i18n/base"],
-+     }
-+ ]
+    },
+  }
+}
 ```
 
 ### More lint on JSON and YAML in `<i18n>` block
@@ -233,34 +230,23 @@ You can also use [jsonc/vue-custom-block/no-parsing-error](https://ota-meshi.git
 
 The most rules of `eslint-plugin-vue-i18n` require `vue-eslint-parser` to check `<template>` ASTs.
 
-Make sure you have one of the following settings in your **.eslintrc**:
+Make sure you have one of the following settings in your **eslint.config.js**:
 
-- `"extends": ["plugin:@intlify/vue-i18n/recommended"]`
-- `"extends": ["plugin:@intlify/vue-i18n/base"]`
+- `plugin.configs.base`
+- `plugin.configs.recommended`
 
-If you already use other parser (e.g. `"parser": "babel-eslint"`), please move it into `parserOptions`, so it doesn't collide with the `vue-eslint-parser` used by this plugin's configuration:
-
-```diff
-- "parser": "babel-eslint",
-  "parserOptions": {
-+     "parser": "babel-eslint",
-      "ecmaVersion": 2017,
-      "sourceType": "module"
-  }
-```
-
-See also: "[Use together with custom parsers](#use-together-with-custom-parsers)" section.
+See also: "[How to use custom parser](#how-to-use-custom-parser)" section.
 
 ### Why doesn't it work on .vue file?
 
 1. Make sure you don't have `eslint-plugin-html` in your config. The `eslint-plugin-html` extracts the content from `<script>` tags, but `eslint-plugin-vue` requires `<script>` tags and `<template>` tags in order to distinguish template and script in single file components.
 
-```diff
-  "plugins": [
-    "vue",
--   "html"
-  ]
-```
+   ```diff
+     "plugins": [
+       "vue",
+   -   "html"
+     ]
+   ```
 
 2. Make sure your tool is set to lint `.vue` and `.json` files.
 

--- a/docs/started.md
+++ b/docs/started.md
@@ -29,7 +29,7 @@ import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 export default [
   // add more generic rulesets here, such as:
   // js.configs.recommended, // '@eslint/js'
-  // ...vue.configs.['flat/recommended'], // 'eslint-plugin-vue'
+  // ...vue.configs['flat/recommended'], // 'eslint-plugin-vue'
 
   ...vueI18n.configs.recommended,
   {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,9 @@
 /** DON'T EDIT THIS FILE; was created by scripts. */
 // configs
-import base from './configs/base'
-import recommended from './configs/recommended'
-import flatBase from './configs/flat/base'
-import flatRecommended from './configs/flat/recommended'
+import baseLegacy from './configs/base'
+import recommendedLegacy from './configs/recommended'
+import base from './configs/flat/base'
+import recommended from './configs/flat/recommended'
 
 // rules
 import keyFormatStyle from './rules/key-format-style'
@@ -32,12 +32,14 @@ import validMessageSyntax from './rules/valid-message-syntax'
 export = {
   configs: {
     // eslintrc configs
-    base,
-    recommended,
+    'base-legacy': baseLegacy,
+    'recommended-legacy': recommendedLegacy,
 
     // flat configs
-    'flat/base': flatBase,
-    'flat/recommended': flatRecommended
+    base,
+    recommended,
+    'flat/base': base,
+    'flat/recommended': recommended
   },
   rules: {
     'key-format-style': keyFormatStyle,

--- a/scripts/update-index.ts
+++ b/scripts/update-index.ts
@@ -9,11 +9,11 @@ export async function update() {
   const raw = `/** DON'T EDIT THIS FILE; was created by scripts. */
 // configs
 ${PRESETS.map(
-  preset => `import ${camelCase(preset)} from './configs/${preset}';`
+  preset =>
+    `import ${camelCase(`${preset}-legacy`)} from './configs/${preset}';`
 ).join('\n')}
 ${PRESETS.map(
-  preset =>
-    `import ${camelCase(`flat-${preset}`)} from './configs/flat/${preset}';`
+  preset => `import ${camelCase(`${preset}`)} from './configs/flat/${preset}';`
 ).join('\n')}
 
 // rules
@@ -25,12 +25,12 @@ ${ruleNames
 export = {
   configs: {
     // eslintrc configs
-    ${PRESETS.map(preset => `'${preset}': ${camelCase(preset)},`).join('\n')}
+    ${PRESETS.map(preset => `'${preset}-legacy': ${camelCase(`${preset}-legacy`)},`).join('\n')}
 
     // flat configs
-    ${PRESETS.map(
-      preset => `'flat/${preset}': ${camelCase(`flat-${preset}`)},`
-    ).join('\n')}
+    ${PRESETS.map(preset => `'${preset}': ${camelCase(preset)},`).join('\n')}
+    // flat configs (Backward compatibility)
+    ${PRESETS.map(preset => `'flat/${preset}': ${camelCase(preset)},`).join('\n')}
   },
   rules: {
     ${ruleNames

--- a/tests/integrations/flat-config/eslint.config.js
+++ b/tests/integrations/flat-config/eslint.config.js
@@ -3,7 +3,7 @@ import vueI18n from '@intlify/eslint-plugin-vue-i18n'
 
 export default [
   ...vue.configs['flat/recommended'],
-  ...vueI18n.configs['flat/recommended'],
+  ...vueI18n.configs.recommended,
   {
     rules: {
       'vue/multi-word-component-names': 'off'

--- a/tests/integrations/legacy-config/.eslintrc.cjs
+++ b/tests/integrations/legacy-config/.eslintrc.cjs
@@ -2,7 +2,10 @@
 
 module.exports = {
   root: true,
-  extends: ['plugin:vue/recommended', 'plugin:@intlify/vue-i18n/recommended-legacy'],
+  extends: [
+    'plugin:vue/recommended',
+    'plugin:@intlify/vue-i18n/recommended-legacy'
+  ],
   rules: {
     'vue/multi-word-component-names': 'off'
   },

--- a/tests/integrations/legacy-config/.eslintrc.cjs
+++ b/tests/integrations/legacy-config/.eslintrc.cjs
@@ -2,7 +2,7 @@
 
 module.exports = {
   root: true,
-  extends: ['plugin:vue/recommended', 'plugin:@intlify/vue-i18n/recommended'],
+  extends: ['plugin:vue/recommended', 'plugin:@intlify/vue-i18n/recommended-legacy'],
   rules: {
     'vue/multi-word-component-names': 'off'
   },


### PR DESCRIPTION
This PR renames the flat configs to `recommended` and the legacy configs to `recommended-legacy`.
`flat/recommended` will remain for backward compatibility.