### PR TITLE
docs: fix "module.export" wrong spells

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -98,7 +98,7 @@ Example `.eslintrc.js`:
 For example:
 
 ```js
-module.export = {
+module.exports = {
   extends: [
     'eslint:recommended',
     // Recommended


### PR DESCRIPTION
should be module.exports