### PR TITLE
Use flat config for eslint 9

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -31,7 +31,7 @@ export default [
   // js.configs.recommended, // '@eslint/js'
   // ...vue.configs['flat/recommended'], // 'eslint-plugin-vue'
 
-  ...vueI18n.configs.recommended,
+  ...vueI18n.configs["flat/recommended"],
   {
     rules: {
       // Optional.

--- a/docs/started.md
+++ b/docs/started.md
@@ -21,6 +21,12 @@ npm install --save-dev eslint @intlify/eslint-plugin-vue-i18n
 
 Use `eslint.config.[c|m]js` file to configure rules. This is the default in ESLint v9, but can be used starting from ESLint v8.57.0. See also: https://eslint.org/docs/latest/use/configure/configuration-files-new.
 
+::: tip Requirements
+
+If you're already toe-tipping and checking out v4.0.0, you should use `vueI18n.configs.recommended` instead of `vueI18n.configs["flat/recommended"]` in the following example.
+
+:::
+
 Example eslint.config.js:
 
 ```js


### PR DESCRIPTION
If I do not use this, I get the error https://github.com/intlify/eslint-plugin-vue-i18n/issues/508, so I guess the wrong config is referenced in the getting started guide.

I'm using this package `@intlify/eslint-plugin-vue-i18n` in version `3.2.0`.

Maybe good to note in addition: I'm not using `eslint-plugin-vue`, because I want to use some of your linting things in a React environment. Specially your support of `tsx` files, and the extensive list of rules that are available, brought me to this idea.