### PR TITLE
Add Typescript config files to supported filename list

### DIFF
--- a/.changeset/dry-chefs-battle.md
+++ b/.changeset/dry-chefs-battle.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": patch
+---
+
+Add Typescript config files to supported filename list

--- a/lib/utils/parser-config-resolver/should-use-flat-config.ts
+++ b/lib/utils/parser-config-resolver/should-use-flat-config.ts
@@ -48,8 +48,8 @@ function findUp(names: string[], options: { cwd: string }) {
       const target = path.resolve(directory, name)
       const stat = fs.existsSync(target)
         ? fs.statSync(target, {
-          throwIfNoEntry: false
-        })
+            throwIfNoEntry: false
+          })
         : null
       if (stat?.isFile()) {
         return target

--- a/lib/utils/parser-config-resolver/should-use-flat-config.ts
+++ b/lib/utils/parser-config-resolver/should-use-flat-config.ts
@@ -6,7 +6,10 @@ import fs from 'fs'
 const FLAT_CONFIG_FILENAMES = [
   'eslint.config.js',
   'eslint.config.mjs',
-  'eslint.config.cjs'
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  'eslint.config.mts',
+  'eslint.config.cts'
 ]
 /**
  * Returns whether flat config should be used.
@@ -45,8 +48,8 @@ function findUp(names: string[], options: { cwd: string }) {
       const target = path.resolve(directory, name)
       const stat = fs.existsSync(target)
         ? fs.statSync(target, {
-            throwIfNoEntry: false
-          })
+          throwIfNoEntry: false
+        })
         : null
       if (stat?.isFile()) {
         return target


### PR DESCRIPTION
Add Typescript config filenames to the lookup list (fix `@intlify/vue-i18n/no-unused-keys ` not working with Typescript-based configs)