### PR TITLE
Fix not triggering rule no-dynamic-keys in non-vue files

### DIFF
--- a/.changeset/empty-steaks-stare.md
+++ b/.changeset/empty-steaks-stare.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": minor
+---
+
+Improved to apply no-dynamic-keys rule to non-Vue files as well.

--- a/lib/rules/no-dynamic-keys.ts
+++ b/lib/rules/no-dynamic-keys.ts
@@ -1,7 +1,11 @@
 /**
  * @author kazuya kawaguchi (a.k.a. kazupon)
  */
-import { defineTemplateBodyVisitor, isStaticLiteral } from '../utils/index'
+import {
+  compositingVisitors,
+  defineTemplateBodyVisitor,
+  isStaticLiteral
+} from '../utils/index'
 import type { RuleContext, RuleListener } from '../types'
 import type { AST as VAST } from 'vue-eslint-parser'
 import { createRule } from '../utils/rule'
@@ -93,9 +97,8 @@ function checkCallExpression(
 }
 
 function create(context: RuleContext): RuleListener {
-  return defineTemplateBodyVisitor(
-    context,
-    {
+  return compositingVisitors(
+    defineTemplateBodyVisitor(context, {
       "VAttribute[directive=true][key.name='t']"(node: VAST.VDirective) {
         checkDirective(context, node)
       },
@@ -113,7 +116,7 @@ function create(context: RuleContext): RuleListener {
       CallExpression(node: VAST.ESLintCallExpression) {
         checkCallExpression(context, node)
       }
-    },
+    }),
     {
       CallExpression(node: VAST.ESLintCallExpression) {
         checkCallExpression(context, node)


### PR DESCRIPTION
### Problem

The `no-dynamic-keys` rule isn't being triggered for `.js` and `.ts` files when used with the `@vue/eslint-config-typescript` plugin. You can find a repository with a reproduction of this issue at https://github.com/mcler/no-dynamic-keys-reproduce

### Solution

Modified the rule implementation by adding a `compositingVisitors` function wrapper, following the approach used in the `no-missing-keys` rule.