### PR TITLE
docs: add note about JavaScript-based locale files not being supported

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -177,7 +177,7 @@ This plugin provides some predefined configs. You can use the following configs 
 
 The `localePattern` options does not support SFC i18n custom blocks (`src` attribute), only for resources of files to import when specified in VueI18n's `messages` options (VueI18n v9 and later, `messages` specified in `createI18n`) for resources of files to import.
 
-JavaScript-based locale files (e.g., `.js` and `.ts`) are not currently supported. For more information, please see [#32](https://github.com/intlify/eslint-plugin-vue-i18n/issues/32).
+JavaScript-based locale files have limited support. JavaScript (`.js`) files can be loaded and used with rules that check for missing keys (like `no-missing-keys`), but TypeScript (`.ts`) locale files are not supported. Rules that analyze locale file contents (like `no-duplicate-keys-in-locale` and `no-html-messages`) are not supported for either format. For more information, please see [#32](https://github.com/intlify/eslint-plugin-vue-i18n/issues/32).
 
 :::
 

--- a/docs/started.md
+++ b/docs/started.md
@@ -177,6 +177,8 @@ This plugin provides some predefined configs. You can use the following configs 
 
 The `localePattern` options does not support SFC i18n custom blocks (`src` attribute), only for resources of files to import when specified in VueI18n's `messages` options (VueI18n v9 and later, `messages` specified in `createI18n`) for resources of files to import.
 
+JavaScript-based locale files (e.g., `.js` and `.ts`) are not currently supported. For more information, please see [#32](https://github.com/intlify/eslint-plugin-vue-i18n/issues/32).
+
 :::
 
 ### Running ESLint from command line


### PR DESCRIPTION
This PR adds a note to clarify that JavaScript-based locale files (`.js` and `.ts`) are not currently supported, with a reference to the relevant GitHub issue.

This helps users understand the current limitations of the plugin and provides a link to track the feature request.

Thank you. #32 