### PR TITLE
fix: typo in no-deprecated-v-t.md

### DIFF
--- a/docs/rules/no-deprecated-v-t.md
+++ b/docs/rules/no-deprecated-v-t.md
@@ -10,7 +10,7 @@ since: v3.2.0
 
 - :star: The `"extends": "plugin:@intlify/vue-i18n/recommended"` or `*.configs["flat/recommended"]` property in a configuration file enables this rule.
 
-If you are migrating from Vue I18n v10 to v11, `v-t` custom direcitve should be replaced with `t` or `$t`.
+If you are migrating from Vue I18n v10 to v11, `v-t` custom directive should be replaced with `t` or `$t`.
 
 ## :book: Rule Details
 


### PR DESCRIPTION
Fixed a small typo :) should be `directive` and not `direcitve`