### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/.changeset/unlucky-grapes-tie.md
+++ b/.changeset/unlucky-grapes-tie.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": minor
+---
+
+fix(no-raw-text): disallow extra properties in rule options

--- a/lib/rules/no-raw-text.ts
+++ b/lib/rules/no-raw-text.ts
@@ -839,7 +839,8 @@ export = createRule({
           ignoreText: {
             type: 'array'
           }
-        }
+        },
+        additionalProperties: false
       }
     ]
   },


### PR DESCRIPTION
[no-raw-text](https://github.com/intlify/eslint-plugin-vue-i18n/blob/b2f2e9ca24a3ebffc0ea76df40d8924aed70002e/lib/rules/no-raw-text.ts#L819) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.