### PR TITLE
refactor: replace lodash with vanilla js

### DIFF
--- a/.changeset/purple-cherries-sneeze.md
+++ b/.changeset/purple-cherries-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": minor
+---
+
+refactor: replace lodash with vanilla js

--- a/lib/utils/glob-utils.ts
+++ b/lib/utils/glob-utils.ts
@@ -224,61 +224,53 @@ export function listFilesToProcess(
     })
   })
 
-  const seenPathDescriptors = new Set<string>()
-  const allPathDescriptors = resolvedPathsByGlobPattern.reduce(
-    (pathsForAllGlobs, pathsForCurrentGlob, index) => {
-      if (
-        pathsForCurrentGlob.every(
-          pathDescriptor => pathDescriptor?.behavior === SILENTLY_IGNORE
-        )
-      ) {
-        throw new (
-          pathsForCurrentGlob.length ? AllFilesIgnoredError : NoFilesFoundError
-        )(globPatterns[index])
+  const allPathDescriptors = resolvedPathsByGlobPattern.reduce<
+    Map<string, /* file name */ boolean /* is ignored */>
+  >((pathsForAllGlobs, pathsForCurrentGlob, index) => {
+    if (
+      pathsForCurrentGlob.every(
+        pathDescriptor => pathDescriptor?.behavior === SILENTLY_IGNORE
+      )
+    ) {
+      throw new (
+        pathsForCurrentGlob.length ? AllFilesIgnoredError : NoFilesFoundError
+      )(globPatterns[index])
+    }
+
+    pathsForCurrentGlob.forEach(pathDescriptor => {
+      if (!pathDescriptor || pathsForAllGlobs.has(pathDescriptor.filename)) {
+        return
       }
 
-      pathsForCurrentGlob.forEach(pathDescriptor => {
-        if (
-          !pathDescriptor ||
-          seenPathDescriptors.has(pathDescriptor.filename)
-        ) {
-          return
-        }
+      switch (pathDescriptor.behavior) {
+        case NORMAL_LINT:
+          pathsForAllGlobs.set(pathDescriptor.filename, false)
+          break
+        case IGNORE_AND_WARN:
+          pathsForAllGlobs.set(pathDescriptor.filename, true)
+          break
+        case SILENTLY_IGNORE:
+          // do nothing
+          break
 
-        switch (pathDescriptor.behavior) {
-          case NORMAL_LINT:
-            seenPathDescriptors.add(pathDescriptor.filename)
-            pathsForAllGlobs.push({
-              filename: pathDescriptor.filename,
-              ignored: false
-            })
-            break
-          case IGNORE_AND_WARN:
-            seenPathDescriptors.add(pathDescriptor.filename)
-            pathsForAllGlobs.push({
-              filename: pathDescriptor.filename,
-              ignored: true
-            })
-            break
-          case SILENTLY_IGNORE:
-            // do nothing
-            break
+        default:
+          throw new Error(
+            `Unexpected file behavior for ${pathDescriptor.filename}`
+          )
+      }
+    })
 
-          default:
-            throw new Error(
-              `Unexpected file behavior for ${pathDescriptor.filename}`
-            )
-        }
-      })
+    return pathsForAllGlobs
+  }, new Map())
 
-      return pathsForAllGlobs
-    },
-    [] as {
-      filename: string
-      ignored: boolean
-    }[]
+  const result = Array.from(
+    allPathDescriptors.entries(),
+    ([filename, ignored]) => ({
+      filename,
+      ignored
+    })
   )
 
-  debug(allPathDescriptors)
-  return allPathDescriptors
+  debug(result)
+  return result
 }

--- a/lib/utils/glob-utils.ts
+++ b/lib/utils/glob-utils.ts
@@ -4,7 +4,6 @@
  * @see https://github.com/eslint/eslint/blob/v5.2.0/lib/util/glob-util.js
  * @author kazuya kawaguchi (a.k.a. kazupon)
  */
-import { uniqBy } from 'lodash'
 import { existsSync, statSync, realpathSync } from 'fs'
 import { resolve } from 'path'
 import { globSync } from 'glob'
@@ -225,6 +224,7 @@ export function listFilesToProcess(
     })
   })
 
+  const seenPathDescriptors = new Set<string>()
   const allPathDescriptors = resolvedPathsByGlobPattern.reduce(
     (pathsForAllGlobs, pathsForCurrentGlob, index) => {
       if (
@@ -238,14 +238,23 @@ export function listFilesToProcess(
       }
 
       pathsForCurrentGlob.forEach(pathDescriptor => {
-        switch (pathDescriptor?.behavior) {
+        if (
+          !pathDescriptor ||
+          seenPathDescriptors.has(pathDescriptor.filename)
+        ) {
+          return
+        }
+
+        switch (pathDescriptor.behavior) {
           case NORMAL_LINT:
+            seenPathDescriptors.add(pathDescriptor.filename)
             pathsForAllGlobs.push({
               filename: pathDescriptor.filename,
               ignored: false
             })
             break
           case IGNORE_AND_WARN:
+            seenPathDescriptors.add(pathDescriptor.filename)
             pathsForAllGlobs.push({
               filename: pathDescriptor.filename,
               ignored: true
@@ -257,7 +266,7 @@ export function listFilesToProcess(
 
           default:
             throw new Error(
-              `Unexpected file behavior for ${pathDescriptor?.filename}`
+              `Unexpected file behavior for ${pathDescriptor.filename}`
             )
         }
       })
@@ -270,10 +279,6 @@ export function listFilesToProcess(
     }[]
   )
 
-  const ret = uniqBy(
-    allPathDescriptors,
-    pathDescriptor => pathDescriptor.filename
-  )
-  debug(ret)
-  return ret
+  debug(allPathDescriptors)
+  return allPathDescriptors
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "is-language-code": "^3.1.0",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
-    "lodash": "^4.17.21",
     "parse5": "^7.1.2",
     "semver": "^7.5.4",
     "synckit": "^0.11.0"
@@ -86,7 +85,6 @@
     "@types/glob": "^9.0.0",
     "@types/js-yaml": "^4.0.5",
     "@types/json-schema": "^7.0.12",
-    "@types/lodash": "^4.14.196",
     "@types/mocha": "^10.0.1",
     "@types/node": "^24.0.0",
     "@types/prettier": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       json5:
         specifier: ^2.2.3
         version: 2.2.3
-      lodash:
-        specifier: ^4.17.21
-        version: 4.18.1
       parse5:
         specifier: ^7.1.2
         version: 7.1.2
@@ -81,9 +78,6 @@ importers:
       '@types/json-schema':
         specifier: ^7.0.12
         version: 7.0.12
-      '@types/lodash':
-        specifier: ^4.14.196
-        version: 4.14.196
       '@types/mocha':
         specifier: ^10.0.1
         version: 10.0.1
@@ -1074,9 +1068,6 @@ packages:
 
   '@types/linkify-it@3.0.5':
     resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
-
-  '@types/lodash@4.14.196':
-    resolution: {integrity: sha512-22y3o88f4a94mKljsZcanlNWPzO0uBsBdzLAngf2tp533LzZcQzb6+eZPJ+vCTt+bqF2XnvT9gejTLsAcJAJyQ==}
 
   '@types/markdown-it@13.0.7':
     resolution: {integrity: sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==}
@@ -4376,8 +4367,6 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@3.0.5': {}
-
-  '@types/lodash@4.14.196': {}
 
   '@types/markdown-it@13.0.7':
     dependencies:


### PR DESCRIPTION
This PR removes `lodash` dependency in favor of vanilla js implementation of the same functionality.