### PR TITLE
fix(no-raw-text): trim whitespace in warning message

### DIFF
--- a/.changeset/trim-no-raw-text-warning.md
+++ b/.changeset/trim-no-raw-text-warning.md
@@ -1,0 +1,5 @@
+---
+"@intlify/eslint-plugin-vue-i18n": patch
+---
+
+fix(no-raw-text): trim leading and trailing whitespace in warning message for readability

--- a/lib/rules/no-raw-text.ts
+++ b/lib/rules/no-raw-text.ts
@@ -217,7 +217,7 @@ function checkLiteral(
   const loc = calculateLoc(literal, baseNode, context)
   context.report({
     loc,
-    message: `raw text '${value}' is used`,
+    message: `raw text '${`${value}`.trim()}' is used`,
     suggest: buildSuggest()
   })
 
@@ -284,7 +284,7 @@ function checkVAttribute(
   const loc = calculateLoc(literal, baseNode, context)
   context.report({
     loc,
-    message: `raw text '${value}' is used`,
+    message: `raw text '${`${value}`.trim()}' is used`,
     suggest: buildSuggest()
   })
 
@@ -363,7 +363,7 @@ function checkText(
   const loc = calculateLoc(textNode, baseNode, context)
   context.report({
     loc,
-    message: `raw text '${value}' is used`,
+    message: `raw text '${value.trim()}' is used`,
     suggest: buildSuggest()
   })
 

--- a/tests/lib/rules/no-raw-text.ts
+++ b/tests/lib/rules/no-raw-text.ts
@@ -1621,6 +1621,38 @@ tester.run('no-raw-text', rule as never, {
           ]
         }
       ]
+    },
+    {
+      // text node with surrounding whitespace: warning message trims for readability
+      code: `<template>
+  <div>
+    raw text
+  </div>
+</template>`,
+      errors: [
+        {
+          message: `raw text 'raw text' is used`,
+          suggestions: [
+            {
+              desc: "Add the resource to the '<i18n>' block.",
+              output:
+                '<i18n>\n' +
+                '{\n' +
+                '  "en": {\n' +
+                '    "\\n    raw text\\n  ": "\\n    raw text\\n  "\n' +
+                '  }\n' +
+                '}\n' +
+                '</i18n>\n' +
+                '\n' +
+                '<template>\n' +
+                '  <div>{{$t(`\n' +
+                '    raw text\n' +
+                '  `)}}</div>\n' +
+                '</template>'
+            }
+          ]
+        }
+      ]
     }
   ]
 })


### PR DESCRIPTION
Closes #664. Trims leading and trailing whitespace from the raw text shown inside the rule's warning message so multi-line text-node violations render readably. Behavior of `testValue`, suggestions, and key extraction is unchanged.