### PR TITLE
fix(no-unused-keys): avoid overwriting prefix keys

### DIFF
--- a/.changeset/fix-no-unused-keys-prefix-overlap.md
+++ b/.changeset/fix-no-unused-keys-prefix-overlap.md
@@ -1,0 +1,5 @@
+---
+'@intlify/eslint-plugin-vue-i18n': patch
+---
+
+Fix false positives in `no-unused-keys` when a used key is a prefix of another used key.

--- a/lib/rules/no-unused-keys.ts
+++ b/lib/rules/no-unused-keys.ts
@@ -58,7 +58,7 @@ function getUsedKeysMap(
   const usedKeysMap: UsedKeys = {}
 
   for (const key of [...usedkeys, ...collectLinkedKeys(values, context)]) {
-    usedKeysMap[key] = {} // Set original key.
+    usedKeysMap[key] = usedKeysMap[key] || {} // Set original key.
     const paths = parsePath(key)
     let map = usedKeysMap
     while (paths.length) {

--- a/tests/fixtures/no-unused-keys/valid/vue3-sfc-local-overlap/locales/en-GB.json
+++ b/tests/fixtures/no-unused-keys/valid/vue3-sfc-local-overlap/locales/en-GB.json
@@ -1,0 +1,5 @@
+{
+  "action": {
+    "close": "Close"
+  }
+}

--- a/tests/fixtures/no-unused-keys/valid/vue3-sfc-local-overlap/src/App.vue
+++ b/tests/fixtures/no-unused-keys/valid/vue3-sfc-local-overlap/src/App.vue
@@ -1,0 +1,23 @@
+<template>
+  <main>
+    <button type="button">
+      {{ t('action.close') }}
+    </button>
+
+    <p>
+      {{ t('action') }}
+    </p>
+  </main>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>
+
+<i18n locale="en-GB">
+{
+  "action": "Local action label"
+}
+</i18n>

--- a/tests/lib/rules/no-unused-keys.ts
+++ b/tests/lib/rules/no-unused-keys.ts
@@ -136,6 +136,16 @@ new RuleTester({
     }),
     ...getTestCasesFromFixtures({
       eslint: '>=6',
+      cwd: join(cwdRoot, './valid/vue3-sfc-local-overlap'),
+      localeDir: `./locales/*.json`,
+      options: [
+        {
+          src: '.'
+        }
+      ]
+    }),
+    ...getTestCasesFromFixtures({
+      eslint: '>=6',
       cwd: join(cwdRoot, './valid/constructor-option-format'),
       localeDir: {
         pattern: `./locales/*.{json,yaml,yml}`,
@@ -2064,6 +2074,7 @@ ${' '.repeat(6)}
         'path-locales/locales/ja/message.yaml': true,
         'path-locales/src/App.vue': true,
         'path-locales/src/main.js': true,
+        'vue3-sfc-local-overlap/src/App.vue': true,
         'vue-cli-format/src/App.vue': true,
         'vue-cli-format/src/main.js': true,
         'constructor-option-format/locales/index.json': {
@@ -2117,6 +2128,16 @@ ${' '.repeat(6)}
           ]
         },
         'multiple-locales/locales3/index.json': {
+          output: null,
+          errors: [
+            {
+              line: 1,
+              message:
+                "You need to set 'localeDir' at 'settings', or '<i18n>' blocks. See the 'eslint-plugin-vue-i18n' documentation"
+            }
+          ]
+        },
+        'vue3-sfc-local-overlap/locales/en-GB.json': {
           output: null,
           errors: [
             {


### PR DESCRIPTION
### Summary
Fixes [#737](https://github.com/intlify/eslint-plugin-vue-i18n/issues/737)

When a used i18n key is a prefix of another used key, `no-unused-keys` can incorrectly report the longer key as unused.

The rule builds a `usedKeysMap` for collected i18n keys. During this process it stores the original key with:

```ts
usedKeysMap[key] = {}
```

Then it also builds a nested path from the same key. If `action.close` is processed first, the map contains the nested branch for `action.close`. If action is processed later, `usedKeysMap['action'] = {}` overwrites the existing `action` branch, removing `action.close` from the used-key tree. As a result, `action.close` is reported as unused even though it is used.

This happens in Vue projects that use global JSON locale files together with local SFC `i18n` blocks.

**Changes**
`lib/rules/no-unused-keys.ts`: Preserve existing `usedKeysMap` branches when storing the original key, instead of overwriting them.

Test fixture `(tests/fixtures/no-unused-keys/valid/vue3-sfc-local-overlap/)`: Minimal reproduction with a global JSON key `action.close` and a local SFC `i18n` key `action`.

Test case in `tests/lib/rules/no-unused-keys.ts`: Verifies that the fixture is valid and `action.close` is not reported as unused.
